### PR TITLE
[Bugfix] Accept file-type-only quant types (IQ2_M, IQ3_XS, ...) in remote GGUF model IDs

### DIFF
--- a/tests/test_gguf_utils.py
+++ b/tests/test_gguf_utils.py
@@ -43,6 +43,23 @@ class TestIsRemoteGGUF:
         assert not is_remote_gguf("repo/model:INVALID_M")
         assert not is_remote_gguf("repo/model:Q9_K_M")
 
+    def test_is_remote_gguf_file_type_only_quants(self):
+        """Test is_remote_gguf with file-type-only quants (LlamaFileType).
+
+        IQ2_M / IQ3_M / IQ3_XS / MXFP4_MOE exist only as GGUF file types
+        (LlamaFileType), not as GGML tensor types. Regression test for
+        https://github.com/vllm-project/vllm/issues/42734.
+        """
+        assert is_remote_gguf("unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ2_M")
+        assert is_remote_gguf("repo/model:IQ2_M")
+        assert is_remote_gguf("repo/model:IQ3_M")
+        assert is_remote_gguf("repo/model:IQ3_XS")
+        assert is_remote_gguf("repo/model:MXFP4_MOE")
+        assert is_remote_gguf("user/Model-GGUF:UD-IQ3_XS")
+
+        assert not is_remote_gguf("repo/model:IQ9_M")
+        assert not is_remote_gguf("repo/model:NOTATYPE")
+
     def test_is_remote_gguf_nonstandard_quant_type(self):
         """Test is_remote_gguf with non-standard quant types containing
         a known GGML type."""

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import gguf
 import regex as re
-from gguf.constants import Keys, VisionProjectorType
+from gguf.constants import Keys, LlamaFileType, VisionProjectorType
 from gguf.quants import GGMLQuantizationType
 from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 from vllm.logger import init_logger
@@ -88,10 +88,18 @@ _GGUF_QUANT_SUFFIXES = ("_M", "_S", "_L", "_XL", "_XS", "_XXS")
 def is_valid_gguf_quant_type(gguf_quant_type: str) -> bool:
     """Check if the quant type is a valid GGUF quant type.
 
-    Supports both exact GGML quant types (e.g., Q4_K, IQ1_S) and
-    extended naming conventions (e.g., Q4_K_M, Q3_K_S, Q5_K_L).
+    The quant type in a ``repo_id:quant_type`` reference is a GGUF *file*
+    type (``LlamaFileType``, members prefixed ``MOSTLY_``), which is distinct
+    from a GGML *tensor* type (``GGMLQuantizationType``). Some file types
+    (e.g. ``IQ2_M``, ``IQ3_XS``, ``MXFP4_MOE``) have no ``GGMLQuantizationType``
+    member, so accept either enum, plus extended naming conventions
+    (e.g. ``Q4_K_M`` -> ``Q4_K``).
     """
-    # Check for exact match first
+    # File type (LlamaFileType), e.g. IQ2_M / MXFP4_MOE with no tensor type
+    if getattr(LlamaFileType, f"MOSTLY_{gguf_quant_type}", None) is not None:
+        return True
+
+    # Exact GGML tensor type
     if getattr(GGMLQuantizationType, gguf_quant_type, None) is not None:
         return True
 


### PR DESCRIPTION
## Purpose

Port the fix approved at vllm-project/vllm#44218 to the plugin, as @Isotr0py requested there (GGUF support is migrating here per #39612). Fixes vllm-project/vllm#42734.

`vllm serve <repo>:UD-IQ2_M` (and any `repo_id:quant_type` reference whose quant is `IQ2_M`, `IQ3_M`, `IQ3_XS`, or `MXFP4_MOE`) fails with `Repo id must use alphanumeric chars...`: the whole string is treated as a plain repo id instead of a remote GGUF reference.

**Root cause.** `is_valid_gguf_quant_type()` only checks `GGMLQuantizationType` (the *tensor* quantization enum), but the `quant_type` in a `repo_id:quant_type` reference is a GGUF *file* type (`LlamaFileType`) used to select the `.gguf` file. These are two distinct gguf enums, and `IQ2_M`/`IQ3_M`/`IQ3_XS`/`MXFP4_MOE` exist only in `LlamaFileType` — they have no `GGMLQuantizationType` member, and no valid base after suffix stripping (`IQ2_M` → `IQ2`, which doesn't exist). So `is_remote_gguf()` returns `False` and the reference is rejected. `UD-IQ1_S`/`UD-IQ1_M` work only because `IQ1_S`/`IQ1_M` happen to exist in *both* enums.

This matches the upstream conclusion in ggml-org/llama.cpp#23085: the gguf maintainer confirms this is a downstream issue and that `general.file_type` must be parsed with `LlamaFileType`. It also cannot be addressed by adding `IQ2_M` to `GGMLQuantizationType` upstream, because `GGMLQuantizationType.IQ1_M` and `LlamaFileType.MOSTLY_IQ2_M` both equal `29` in the shared int space.

**Fix.** Accept either enum in `is_valid_gguf_quant_type()`: a `LlamaFileType` file type (members are prefixed `MOSTLY_`) or a `GGMLQuantizationType` tensor type. The existing suffix handling for extended names (e.g. `Q4_K_M` → `Q4_K`) is preserved. Minimal change, no special-case table, so newly added file types are picked up automatically.

## Test Plan

Unit: extend `tests/test_gguf_utils.py::TestIsRemoteGGUF` to cover file-type-only quants (`IQ2_M`/`IQ3_M`/`IQ3_XS`/`MXFP4_MOE`), with and without a vendor prefix (`UD-`), plus negative cases (`IQ9_M`, `NOTATYPE`). Each new assertion was confirmed to fail on the unpatched code and pass after the fix.

## Test Result

```
$ pytest tests/test_gguf_utils.py -q
25 passed
```

Before the fix the new cases fail (e.g. `is_remote_gguf("unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ2_M")` returns `False`, reproducing the reported `Repo id must use alphanumeric chars...`); after the fix all 25 pass. `ruff check`, `ruff format`, and `typos` are clean on the changed files.

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.
