### PR TITLE
Route GGUF NVFP4 through native vLLM linear kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,33 @@ The same hooks also run in GitHub Actions on every push and pull request.
 ```bash
 vllm serve Qwen/Qwen3-0.6B-GGUF:Q8_0 --tokenizer Qwen/Qwen3-0.6B
 ```
+
+## Smoke Tests
+
+Check registration behavior without loading a model:
+
+```bash
+python scripts/plugin_gguf_smoke.py --json
+```
+
+Force the plugin to take ownership from an in-tree GGUF vLLM build:
+
+```bash
+python scripts/plugin_gguf_smoke.py --override-in-tree --expect active --json
+```
+
+Exercise the real vLLM GGUF load path with a local model:
+
+```bash
+python scripts/plugin_gguf_smoke.py \
+  --override-in-tree \
+  --expect active \
+  --generate \
+  --model /path/to/model.gguf \
+  --tokenizer /path/to/tokenizer \
+  --hf-config-path /path/to/hf-config \
+  --max-model-len 1024 \
+  --gpu-memory-utilization 0.25 \
+  --enforce-eager \
+  --json
+```

--- a/scripts/plugin_gguf_smoke.py
+++ b/scripts/plugin_gguf_smoke.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Smoke-test vllm-gguf-plugin registration and optional GGUF generation.
+
+The default mode is intentionally lightweight: it imports vLLM, calls the
+plugin's register hook, and reports whether GGUF is served by in-tree vLLM or by
+this out-of-tree plugin. Pass --generate with a small local GGUF plus tokenizer
+and config to exercise the real vLLM load/generate path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def object_module(value: Any) -> str:
+    return getattr(value, "__module__", type(value).__module__)
+
+
+def object_name(value: Any) -> str:
+    return getattr(value, "__name__", type(value).__name__)
+
+
+def plugin_quantization_imported() -> bool:
+    return any(
+        name == "vllm_gguf_plugin.quantization"
+        or name.startswith("vllm_gguf_plugin.quantization.")
+        for name in sys.modules
+    )
+
+
+def ensure_python_bin_on_path() -> None:
+    python_bin = Path(sys.executable).parent
+    os.environ["PATH"] = f"{python_bin}:{os.environ.get('PATH', '')}"
+
+
+def plugin_version() -> str:
+    try:
+        return metadata.version("vllm-gguf-plugin")
+    except metadata.PackageNotFoundError:
+        return "source-checkout"
+
+
+def import_state() -> dict[str, Any]:
+    import vllm
+    from vllm.config.load import LoadConfig
+    from vllm.model_executor.layers.quantization import (
+        QUANTIZATION_METHODS,
+        get_quantization_config,
+    )
+    from vllm.model_executor.model_loader import get_model_loader
+    from vllm.transformers_utils.config import get_config_parser
+
+    in_tree = "gguf" in QUANTIZATION_METHODS
+    quant_config: Any | None = None
+    model_loader: Any | None = None
+    config_parser: Any | None = None
+    errors: dict[str, str] = {}
+
+    if in_tree:
+        try:
+            quant_config = get_quantization_config("gguf")
+        except Exception as exc:  # pragma: no cover - diagnostic path
+            errors["quant_config"] = f"{type(exc).__name__}: {exc}"
+        try:
+            model_loader = get_model_loader(LoadConfig(load_format="gguf"))
+        except Exception as exc:
+            errors["model_loader"] = f"{type(exc).__name__}: {exc}"
+        try:
+            config_parser = get_config_parser("gguf")
+        except Exception as exc:
+            errors["config_parser"] = f"{type(exc).__name__}: {exc}"
+
+    return {
+        "vllmVersion": getattr(vllm, "__version__", None),
+        "hasGgufQuantization": in_tree,
+        "quantizationMethodsHasGguf": in_tree,
+        "quantConfig": None
+        if quant_config is None
+        else f"{object_module(quant_config)}.{object_name(quant_config)}",
+        "modelLoader": None
+        if model_loader is None
+        else f"{object_module(type(model_loader))}.{object_name(type(model_loader))}",
+        "configParser": None
+        if config_parser is None
+        else f"{object_module(type(config_parser))}.{object_name(type(config_parser))}",
+        "pluginQuantizationImported": plugin_quantization_imported(),
+        "errors": errors,
+    }
+
+
+def expected_verdict(args: argparse.Namespace, before: dict[str, Any]) -> str:
+    if args.expect != "auto":
+        return args.expect
+    if before["hasGgufQuantization"] and not args.override_in_tree:
+        return "skipped"
+    return "active"
+
+
+def actual_verdict(after: dict[str, Any]) -> str:
+    quant = after.get("quantConfig") or ""
+    loader = after.get("modelLoader") or ""
+    parser = after.get("configParser") or ""
+    plugin_owned = (
+        quant.startswith("vllm_gguf_plugin.")
+        and loader.startswith("vllm_gguf_plugin.")
+        and parser.startswith("vllm_gguf_plugin.")
+    )
+    return "active" if plugin_owned else "skipped"
+
+
+def run_generation(args: argparse.Namespace) -> dict[str, Any] | None:
+    if not args.generate:
+        return None
+    if not args.model:
+        raise SystemExit("--generate requires --model")
+    if not args.tokenizer:
+        raise SystemExit("--generate requires --tokenizer")
+
+    from vllm import LLM, SamplingParams
+
+    kwargs: dict[str, Any] = {
+        "model": args.model,
+        "tokenizer": args.tokenizer,
+        "load_format": "gguf",
+        "quantization": "gguf",
+        "dtype": args.dtype,
+        "max_model_len": args.max_model_len,
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "enforce_eager": args.enforce_eager,
+        "trust_remote_code": args.trust_remote_code,
+    }
+    if args.hf_config_path:
+        kwargs["hf_config_path"] = args.hf_config_path
+
+    llm = LLM(**kwargs)
+    outputs = llm.generate(
+        [args.prompt],
+        SamplingParams(
+            temperature=0.0,
+            max_tokens=args.max_tokens,
+        ),
+    )
+    text = outputs[0].outputs[0].text if outputs and outputs[0].outputs else ""
+    return {
+        "model": args.model,
+        "prompt": args.prompt,
+        "text": text,
+        "tokens": len(outputs[0].outputs[0].token_ids)
+        if outputs and outputs[0].outputs
+        else 0,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expect", choices=["auto", "active", "skipped"], default="auto")
+    parser.add_argument("--override-in-tree", action="store_true")
+    parser.add_argument("--generate", action="store_true")
+    parser.add_argument("--model")
+    parser.add_argument("--tokenizer")
+    parser.add_argument("--hf-config-path")
+    parser.add_argument("--dtype", default="float16")
+    parser.add_argument("--max-model-len", type=int, default=1024)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.25)
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--prompt", default="Reply with exactly: gguf ok")
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    ensure_python_bin_on_path()
+    if args.override_in_tree:
+        os.environ["VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE"] = "1"
+
+    before = import_state()
+
+    import vllm_gguf_plugin
+
+    imported_without_quantization = not plugin_quantization_imported()
+    vllm_gguf_plugin.register()
+    after = import_state()
+
+    expected = expected_verdict(args, before)
+    actual = actual_verdict(after)
+    ok = actual == expected and imported_without_quantization
+
+    generation = None
+    if ok:
+        generation = run_generation(args)
+
+    result = {
+        "ok": ok,
+        "expected": expected,
+        "actual": actual,
+        "python": sys.executable,
+        "pluginVersion": plugin_version(),
+        "importedWithoutQuantization": imported_without_quantization,
+        "before": before,
+        "after": after,
+        "generation": generation,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"vllm-gguf-plugin smoke: expected={expected} actual={actual} "
+            f"ok={str(ok).lower()}"
+        )
+        print(
+            f"vllm={after['vllmVersion']} plugin={result['pluginVersion']} "
+            f"quant={after['quantConfig']} loader={after['modelLoader']} "
+            f"parser={after['configParser']}"
+        )
+        if generation:
+            print(f"generation tokens={generation['tokens']} text={generation['text']!r}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -7,7 +7,13 @@ import pytest
 from vllm.config.load import LoadConfig
 
 from vllm_gguf_plugin.loader import GGUFModelLoader
-from vllm_gguf_plugin.weight_utils import download_gguf, resolve_gguf_file_set
+from vllm_gguf_plugin.weight_utils import (
+    download_gguf,
+    download_gguf_file,
+    resolve_gguf_file_set,
+    resolve_local_gguf,
+    split_remote_gguf_file_ref,
+)
 
 
 class TestSplitGGUFResolution:
@@ -22,9 +28,7 @@ class TestSplitGGUFResolution:
         for idx in range(1, 4):
             (tmp_path / f"model-Q4_K_M-0000{idx}-of-00003.gguf").touch()
 
-        result = resolve_gguf_file_set(
-            tmp_path / "model-Q4_K_M-00002-of-00003.gguf"
-        )
+        result = resolve_gguf_file_set(tmp_path / "model-Q4_K_M-00002-of-00003.gguf")
 
         assert result == [
             str(tmp_path / "model-Q4_K_M-00001-of-00003.gguf"),
@@ -38,6 +42,25 @@ class TestSplitGGUFResolution:
 
         with pytest.raises(ValueError, match="Incomplete split GGUF model"):
             resolve_gguf_file_set(tmp_path / "model-Q4_K_M-00001-of-00003.gguf")
+
+
+class TestRemoteGGUFFileRefs:
+    def test_split_remote_gguf_file_ref_root_file(self):
+        assert split_remote_gguf_file_ref("unsloth/Qwen-GGUF/model.gguf") == (
+            "unsloth/Qwen-GGUF",
+            "model.gguf",
+        )
+
+    def test_split_remote_gguf_file_ref_subdir_file(self):
+        assert split_remote_gguf_file_ref("org/repo/Q4_K_M/model.gguf") == (
+            "org/repo",
+            "Q4_K_M/model.gguf",
+        )
+
+    def test_split_remote_gguf_file_ref_rejects_local_or_unsafe_paths(self):
+        assert split_remote_gguf_file_ref("/tmp/model.gguf") is None
+        assert split_remote_gguf_file_ref("org/repo/../model.gguf") is None
+        assert split_remote_gguf_file_ref("repo/model.gguf") is None
 
 
 class TestGGUFDownload:
@@ -117,6 +140,67 @@ class TestGGUFDownload:
         with pytest.raises(ValueError, match="Downloaded GGUF files not found"):
             download_gguf("unsloth/Qwen3-0.6B-GGUF", "IQ1_S")
 
+    @patch("vllm_gguf_plugin.weight_utils.hf_hub_download")
+    def test_download_gguf_file_single_exact_file(self, mock_hf_download):
+        mock_hf_download.return_value = "/downloaded/Qwen.gguf"
+
+        result = download_gguf_file(
+            "unsloth/Qwen3-0.6B-GGUF",
+            "Qwen3-0.6B-Q8_0.gguf",
+            cache_dir="/cache",
+            revision="abc123",
+        )
+
+        assert result == "/downloaded/Qwen.gguf"
+        mock_hf_download.assert_called_once_with(
+            repo_id="unsloth/Qwen3-0.6B-GGUF",
+            filename="Qwen3-0.6B-Q8_0.gguf",
+            cache_dir="/cache",
+            revision="abc123",
+        )
+
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_file_split_exact_file_set(self, mock_download, tmp_path):
+        mock_download.return_value = str(tmp_path)
+        (tmp_path / "Qwen-Q4_K_M-00001-of-00002.gguf").touch()
+        (tmp_path / "Qwen-Q4_K_M-00002-of-00002.gguf").touch()
+
+        result = download_gguf_file(
+            "org/repo",
+            "Qwen-Q4_K_M-00002-of-00002.gguf",
+            cache_dir="/cache",
+            revision="abc123",
+        )
+
+        assert result == str(tmp_path / "Qwen-Q4_K_M-00001-of-00002.gguf")
+        mock_download.assert_called_once_with(
+            repo_id="org/repo",
+            cache_dir="/cache",
+            allow_patterns=[
+                "Qwen-Q4_K_M-00001-of-00002.gguf",
+                "Qwen-Q4_K_M-00002-of-00002.gguf",
+            ],
+            revision="abc123",
+        )
+
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_file_split_missing_shard_fails(
+        self, mock_download, tmp_path
+    ):
+        mock_download.return_value = str(tmp_path)
+        (tmp_path / "Qwen-Q4_K_M-00001-of-00002.gguf").touch()
+
+        with pytest.raises(ValueError, match="Incomplete split GGUF model"):
+            download_gguf_file("org/repo", "Qwen-Q4_K_M-00001-of-00002.gguf")
+
+    def test_resolve_local_gguf_validates_split_shards(self, tmp_path):
+        (tmp_path / "model-Q4_K_M-00001-of-00002.gguf").touch()
+        (tmp_path / "model-Q4_K_M-00002-of-00002.gguf").touch()
+
+        assert resolve_local_gguf(str(tmp_path), "Q4_K_M") == str(
+            tmp_path / "model-Q4_K_M-00001-of-00002.gguf"
+        )
+
 
 class TestGGUFModelLoader:
     """Test GGUFModelLoader class methods."""
@@ -135,23 +219,52 @@ class TestGGUFModelLoader:
         assert result == "/path/to/model.gguf"
         mock_isfile.assert_called_once_with("/path/to/model.gguf")
 
-    @patch("vllm_gguf_plugin.loader.hf_hub_download")
+    @patch("vllm_gguf_plugin.loader.download_gguf_file")
     @patch("os.path.isfile", return_value=False)
-    def test_prepare_weights_repo_filename(self, mock_isfile, mock_hf_download):
+    def test_prepare_weights_repo_filename(self, mock_isfile, mock_download_file):
         """Test _prepare_weights with repo_id/filename.gguf format."""
         load_config = LoadConfig(load_format="gguf")
         loader = GGUFModelLoader(load_config)
 
-        mock_hf_download.return_value = "/downloaded/model.gguf"
+        mock_download_file.return_value = "/downloaded/model.gguf"
 
         model_config = MagicMock()
         model_config.model_weights = "unsloth/Qwen3-0.6B-GGUF/model.gguf"
         model_config.model = "unsloth/Qwen3-0.6B-GGUF"
+        model_config.revision = "abc123"
 
         result = loader._prepare_weights(model_config)
         assert result == "/downloaded/model.gguf"
-        mock_hf_download.assert_called_once_with(
-            repo_id="unsloth/Qwen3-0.6B-GGUF", filename="model.gguf"
+        mock_download_file.assert_called_once_with(
+            repo_id="unsloth/Qwen3-0.6B-GGUF",
+            filename="model.gguf",
+            cache_dir=None,
+            revision="abc123",
+        )
+
+    @patch("vllm_gguf_plugin.loader.download_gguf_file")
+    @patch("os.path.isfile", return_value=False)
+    def test_prepare_weights_repo_subdir_filename(
+        self, mock_isfile, mock_download_file
+    ):
+        """Test _prepare_weights with repo_id/subdir/filename.gguf format."""
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        mock_download_file.return_value = "/downloaded/model.gguf"
+
+        model_config = MagicMock()
+        model_config.model_weights = "org/repo/Q8_0/model.gguf"
+        model_config.model = "org/repo"
+        model_config.revision = None
+
+        result = loader._prepare_weights(model_config)
+        assert result == "/downloaded/model.gguf"
+        mock_download_file.assert_called_once_with(
+            repo_id="org/repo",
+            filename="Q8_0/model.gguf",
+            cache_dir=None,
+            revision=None,
         )
 
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")

--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -66,8 +66,9 @@ class TestRemoteGGUFFileRefs:
 class TestGGUFDownload:
     """Test GGUF model downloading functionality."""
 
+    @patch("vllm_gguf_plugin.weight_utils.list_repo_files", return_value=[])
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
-    def test_download_gguf_single_file(self, mock_download):
+    def test_download_gguf_single_file(self, mock_download, mock_list_repo_files):
         """Test downloading a single GGUF file."""
         mock_folder = "/tmp/mock_cache"
         mock_download.return_value = mock_folder
@@ -105,9 +106,115 @@ class TestGGUFDownload:
             )
 
             assert result == f"{mock_folder}/model-IQ1_S.gguf"
+            mock_list_repo_files.assert_called_once_with(
+                "unsloth/Qwen3-0.6B-GGUF",
+                revision=None,
+            )
 
+    @patch(
+        "vllm_gguf_plugin.weight_utils.list_repo_files",
+        return_value=[
+            "Qwen3.5-0.8B-Q4_K_M.gguf",
+            "mmproj-BF16.gguf",
+            "mmproj-F16.gguf",
+            "mmproj-F32.gguf",
+        ],
+    )
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
-    def test_download_gguf_sharded_files(self, mock_download, tmp_path):
+    def test_download_gguf_downloads_preferred_f16_mmproj(
+        self,
+        mock_download,
+        mock_list_repo_files,
+        tmp_path,
+    ):
+        mock_download.return_value = str(tmp_path)
+        (tmp_path / "Qwen3.5-0.8B-Q4_K_M.gguf").touch()
+        (tmp_path / "mmproj-F16.gguf").touch()
+
+        result = download_gguf("unsloth/Qwen3.5-0.8B-GGUF", "Q4_K_M")
+
+        assert result == str(tmp_path / "Qwen3.5-0.8B-Q4_K_M.gguf")
+        assert "mmproj-F16.gguf" in mock_download.call_args.kwargs["allow_patterns"]
+        assert (
+            "mmproj-BF16.gguf" not in mock_download.call_args.kwargs["allow_patterns"]
+        )
+        mock_list_repo_files.assert_called_once_with(
+            "unsloth/Qwen3.5-0.8B-GGUF",
+            revision=None,
+        )
+
+    @patch(
+        "vllm_gguf_plugin.weight_utils.list_repo_files",
+        return_value=[
+            "gemma-4-E2B-it-Q8_0.gguf",
+            "mmproj-gemma-4-E2B-it-Q8_0.gguf",
+            "mmproj-gemma-4-E2B-it-bf16.gguf",
+        ],
+    )
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_prefers_quant_matched_mmproj(
+        self,
+        mock_download,
+        mock_list_repo_files,
+        tmp_path,
+    ):
+        mock_download.return_value = str(tmp_path)
+        (tmp_path / "gemma-4-E2B-it-Q8_0.gguf").touch()
+        (tmp_path / "mmproj-gemma-4-E2B-it-Q8_0.gguf").touch()
+
+        result = download_gguf("ggml-org/gemma-4-E2B-it-GGUF", "Q8_0")
+
+        assert result == str(tmp_path / "gemma-4-E2B-it-Q8_0.gguf")
+        assert (
+            "mmproj-gemma-4-E2B-it-Q8_0.gguf"
+            in mock_download.call_args.kwargs["allow_patterns"]
+        )
+        assert (
+            "mmproj-gemma-4-E2B-it-bf16.gguf"
+            not in mock_download.call_args.kwargs["allow_patterns"]
+        )
+        mock_list_repo_files.assert_called_once_with(
+            "ggml-org/gemma-4-E2B-it-GGUF",
+            revision=None,
+        )
+
+    @patch(
+        "vllm_gguf_plugin.weight_utils.list_repo_files",
+        return_value=[
+            "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf",
+            "mmproj-Q4_K_XL.gguf",
+            "mmproj-F16.gguf",
+        ],
+    )
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_matches_mmproj_for_prefixed_quant_type(
+        self,
+        mock_download,
+        mock_list_repo_files,
+        tmp_path,
+    ):
+        mock_download.return_value = str(tmp_path)
+        (tmp_path / "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf").touch()
+        (tmp_path / "mmproj-Q4_K_XL.gguf").touch()
+
+        result = download_gguf("unsloth/Qwen3.5-35B-A3B-GGUF", "UD-Q4_K_XL")
+
+        assert result == str(tmp_path / "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf")
+        assert "mmproj-Q4_K_XL.gguf" in mock_download.call_args.kwargs["allow_patterns"]
+        assert "mmproj-F16.gguf" not in mock_download.call_args.kwargs["allow_patterns"]
+        mock_list_repo_files.assert_called_once_with(
+            "unsloth/Qwen3.5-35B-A3B-GGUF",
+            revision=None,
+        )
+
+    @patch("vllm_gguf_plugin.weight_utils.list_repo_files", return_value=[])
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_sharded_files(
+        self,
+        mock_download,
+        mock_list_repo_files,
+        tmp_path,
+    ):
         """Test downloading sharded GGUF files."""
         mock_folder = str(tmp_path)
         mock_download.return_value = mock_folder
@@ -117,9 +224,14 @@ class TestGGUFDownload:
         result = download_gguf("unsloth/gpt-oss-120b-GGUF", "Q2_K")
 
         assert result == f"{mock_folder}/model-Q2_K-00001-of-00002.gguf"
+        mock_list_repo_files.assert_called_once_with(
+            "unsloth/gpt-oss-120b-GGUF",
+            revision=None,
+        )
 
+    @patch("vllm_gguf_plugin.weight_utils.list_repo_files", return_value=[])
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
-    def test_download_gguf_subdir(self, mock_download, tmp_path):
+    def test_download_gguf_subdir(self, mock_download, mock_list_repo_files, tmp_path):
         """Test downloading GGUF files from subdirectory."""
         mock_folder = str(tmp_path)
         mock_download.return_value = mock_folder
@@ -129,16 +241,30 @@ class TestGGUFDownload:
         result = download_gguf("unsloth/gpt-oss-120b-GGUF", "Q2_K")
 
         assert result == f"{mock_folder}/Q2_K/model-Q2_K.gguf"
+        mock_list_repo_files.assert_called_once_with(
+            "unsloth/gpt-oss-120b-GGUF",
+            revision=None,
+        )
 
+    @patch("vllm_gguf_plugin.weight_utils.list_repo_files", return_value=[])
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
     @patch("glob.glob", return_value=[])
-    def test_download_gguf_no_files_found(self, mock_glob, mock_download):
+    def test_download_gguf_no_files_found(
+        self,
+        mock_glob,
+        mock_download,
+        mock_list_repo_files,
+    ):
         """Test error when no GGUF files are found."""
         mock_folder = "/tmp/mock_cache"
         mock_download.return_value = mock_folder
 
         with pytest.raises(ValueError, match="Downloaded GGUF files not found"):
             download_gguf("unsloth/Qwen3-0.6B-GGUF", "IQ1_S")
+        mock_list_repo_files.assert_called_once_with(
+            "unsloth/Qwen3-0.6B-GGUF",
+            revision=None,
+        )
 
     @patch("vllm_gguf_plugin.weight_utils.hf_hub_download")
     def test_download_gguf_file_single_exact_file(self, mock_hf_download):

--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -7,7 +7,37 @@ import pytest
 from vllm.config.load import LoadConfig
 
 from vllm_gguf_plugin.loader import GGUFModelLoader
-from vllm_gguf_plugin.weight_utils import download_gguf
+from vllm_gguf_plugin.weight_utils import download_gguf, resolve_gguf_file_set
+
+
+class TestSplitGGUFResolution:
+    """Test split GGUF shard discovery and validation."""
+
+    def test_non_split_file_returns_single_path(self):
+        assert resolve_gguf_file_set("/models/model-Q4_K_M.gguf") == [
+            "/models/model-Q4_K_M.gguf"
+        ]
+
+    def test_split_file_resolves_all_shards_from_any_entry_shard(self, tmp_path):
+        for idx in range(1, 4):
+            (tmp_path / f"model-Q4_K_M-0000{idx}-of-00003.gguf").touch()
+
+        result = resolve_gguf_file_set(
+            tmp_path / "model-Q4_K_M-00002-of-00003.gguf"
+        )
+
+        assert result == [
+            str(tmp_path / "model-Q4_K_M-00001-of-00003.gguf"),
+            str(tmp_path / "model-Q4_K_M-00002-of-00003.gguf"),
+            str(tmp_path / "model-Q4_K_M-00003-of-00003.gguf"),
+        ]
+
+    def test_split_file_missing_shard_fails_closed(self, tmp_path):
+        (tmp_path / "model-Q4_K_M-00001-of-00003.gguf").touch()
+        (tmp_path / "model-Q4_K_M-00003-of-00003.gguf").touch()
+
+        with pytest.raises(ValueError, match="Incomplete split GGUF model"):
+            resolve_gguf_file_set(tmp_path / "model-Q4_K_M-00001-of-00003.gguf")
 
 
 class TestGGUFDownload:
@@ -31,13 +61,21 @@ class TestGGUFDownload:
                 cache_dir=None,
                 allow_patterns=[
                     "*.IQ1_S-*.gguf",
+                    "*/*.IQ1_S-*.gguf",
                     "*.IQ1_S.gguf",
+                    "*/*.IQ1_S.gguf",
                     "*-IQ1_S-*.gguf",
+                    "*/*-IQ1_S-*.gguf",
                     "*-IQ1_S.gguf",
+                    "*/*-IQ1_S.gguf",
                     "*.iq1_s-*.gguf",
+                    "*/*.iq1_s-*.gguf",
                     "*.iq1_s.gguf",
+                    "*/*.iq1_s.gguf",
                     "*-iq1_s-*.gguf",
+                    "*/*-iq1_s-*.gguf",
                     "*-iq1_s.gguf",
+                    "*/*-iq1_s.gguf",
                 ],
                 revision=None,
                 ignore_patterns=None,
@@ -46,41 +84,28 @@ class TestGGUFDownload:
             assert result == f"{mock_folder}/model-IQ1_S.gguf"
 
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
-    def test_download_gguf_sharded_files(self, mock_download):
+    def test_download_gguf_sharded_files(self, mock_download, tmp_path):
         """Test downloading sharded GGUF files."""
-        mock_folder = "/tmp/mock_cache"
+        mock_folder = str(tmp_path)
         mock_download.return_value = mock_folder
+        (tmp_path / "model-Q2_K-00001-of-00002.gguf").touch()
+        (tmp_path / "model-Q2_K-00002-of-00002.gguf").touch()
 
-        with patch("glob.glob") as mock_glob:
-            mock_glob.side_effect = lambda pattern, **kwargs: (
-                [
-                    f"{mock_folder}/model-Q2_K-00001-of-00002.gguf",
-                    f"{mock_folder}/model-Q2_K-00002-of-00002.gguf",
-                ]
-                if "Q2_K" in pattern
-                else []
-            )
+        result = download_gguf("unsloth/gpt-oss-120b-GGUF", "Q2_K")
 
-            result = download_gguf("unsloth/gpt-oss-120b-GGUF", "Q2_K")
-
-            assert result == f"{mock_folder}/model-Q2_K-00001-of-00002.gguf"
+        assert result == f"{mock_folder}/model-Q2_K-00001-of-00002.gguf"
 
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
-    def test_download_gguf_subdir(self, mock_download):
+    def test_download_gguf_subdir(self, mock_download, tmp_path):
         """Test downloading GGUF files from subdirectory."""
-        mock_folder = "/tmp/mock_cache"
+        mock_folder = str(tmp_path)
         mock_download.return_value = mock_folder
+        (tmp_path / "Q2_K").mkdir()
+        (tmp_path / "Q2_K" / "model-Q2_K.gguf").touch()
 
-        with patch("glob.glob") as mock_glob:
-            mock_glob.side_effect = lambda pattern, **kwargs: (
-                [f"{mock_folder}/Q2_K/model-Q2_K.gguf"]
-                if "Q2_K" in pattern or "**/*.gguf" in pattern
-                else []
-            )
+        result = download_gguf("unsloth/gpt-oss-120b-GGUF", "Q2_K")
 
-            result = download_gguf("unsloth/gpt-oss-120b-GGUF", "Q2_K")
-
-            assert result == f"{mock_folder}/Q2_K/model-Q2_K.gguf"
+        assert result == f"{mock_folder}/Q2_K/model-Q2_K.gguf"
 
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
     @patch("glob.glob", return_value=[])

--- a/tests/test_gguf_utils.py
+++ b/tests/test_gguf_utils.py
@@ -5,11 +5,13 @@ from unittest.mock import patch
 
 import pytest
 
+import vllm_gguf_plugin.gguf_utils as gguf_utils_module
 from vllm_gguf_plugin.gguf_utils import (
     extract_lm_head_from_gguf,
     is_gguf,
     is_local_gguf_quant,
     is_remote_gguf,
+    resolve_gguf_config_source,
     split_remote_gguf,
 )
 
@@ -213,6 +215,11 @@ class TestIsGGUF:
         assert not is_gguf("repo/model:quant")
         assert not is_gguf("repo/model:INVALID")
 
+    def test_is_gguf_with_exact_remote_file(self):
+        """Test is_gguf with exact remote GGUF file references."""
+        assert is_gguf("org/repo/model.gguf")
+        assert is_gguf("org/repo/subdir/model.gguf")
+
     @patch("vllm_gguf_plugin.gguf_utils.check_gguf_file", return_value=False)
     def test_is_gguf_false(self, mock_check_gguf):
         """Test is_gguf returns False for non-GGUF models."""
@@ -229,6 +236,63 @@ class TestIsGGUF:
         assert not is_gguf("https://repo/model:Q2_K")
         assert not is_gguf("s3://bucket/repo/model:IQ1_S")
         assert not is_gguf("gs://bucket/repo/model:Q2_K")
+
+
+class TestResolveGGUFConfigSource:
+    def test_exact_remote_file_uses_repo_config(self, monkeypatch):
+        calls = []
+
+        def fake_file_or_path_exists(model, filename, revision):
+            calls.append((model, filename, revision))
+            return model == "org/repo" and filename == "config.json"
+
+        def fail_base_model_lookup(repo_id, revision=None):
+            raise AssertionError(
+                "base model lookup should not run when repo has config"
+            )
+
+        monkeypatch.setattr(
+            gguf_utils_module,
+            "_get_remote_gguf_base_model_ids",
+            fail_base_model_lookup,
+        )
+        monkeypatch.setattr(
+            gguf_utils_module,
+            "file_or_path_exists",
+            fake_file_or_path_exists,
+        )
+
+        assert (
+            resolve_gguf_config_source(
+                "org/repo/subdir/model.gguf",
+                revision="main",
+            )
+            == "org/repo"
+        )
+        assert calls == [("org/repo", "config.json", "main")]
+
+    def test_exact_remote_file_can_redirect_to_base_model(self, monkeypatch):
+        def fake_file_or_path_exists(model, filename, revision):
+            return model == "base/model" and filename == "config.json"
+
+        monkeypatch.setattr(
+            gguf_utils_module,
+            "_get_remote_gguf_base_model_ids",
+            lambda repo_id, revision=None: ("base/model",),
+        )
+        monkeypatch.setattr(
+            gguf_utils_module,
+            "file_or_path_exists",
+            fake_file_or_path_exists,
+        )
+
+        assert (
+            resolve_gguf_config_source(
+                "org/repo/subdir/model.gguf",
+                revision="main",
+            )
+            == "base/model"
+        )
 
 
 class TestExtractLMHeadFromGGUF:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -591,6 +591,51 @@ def test_gguf_config_parser_uses_repo_for_exact_remote_file(monkeypatch):
     assert config.architectures == ["Qwen3ForCausalLM"]
 
 
+def test_gguf_config_parser_preserves_multimodal_architecture(monkeypatch):
+    calls = {}
+
+    def fake_parse(
+        self, model, trust_remote_code, revision=None, code_revision=None, **kwargs
+    ):
+        calls["model"] = model
+        calls["trust_remote_code"] = trust_remote_code
+        calls["gguf_file"] = kwargs.get("gguf_file")
+        config = PretrainedConfig(model_type="qwen3_5")
+        config.architectures = ["Qwen3_5ForConditionalGeneration"]
+        return {
+            "model_type": "qwen3_5",
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+        }, config
+
+    monkeypatch.setattr(
+        gguf_config_parser_module.HFConfigParser,
+        "parse",
+        fake_parse,
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: "Qwen/Qwen3.5-0.8B",
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda model, config: config,
+    )
+
+    config_dict, config = GGUFConfigParser().parse(
+        "unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
+        trust_remote_code=True,
+        revision="main",
+    )
+
+    assert calls["model"] == "Qwen/Qwen3.5-0.8B"
+    assert calls["trust_remote_code"] is False
+    assert calls["gguf_file"] is None
+    assert config_dict["architectures"] == ["Qwen3_5ForConditionalGeneration"]
+    assert config.architectures == ["Qwen3_5ForConditionalGeneration"]
+
+
 def test_gguf_config_parser_passes_exact_remote_file_when_repo_has_no_config(
     monkeypatch,
 ):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import torch
+import vllm.config.model as model_config_module
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.model_executor.layers.quantization as quantization_module
 import vllm.model_executor.layers.vocab_parallel_embedding as vocab_embedding_module
@@ -707,12 +708,34 @@ def test_register_preserves_implicit_gguf_model_for_config_parser(monkeypatch):
     assert engine_args.load_format == "gguf"
 
 
-def test_register_skips_speculator_probe_for_gguf():
+def test_register_skips_speculator_probe_for_gguf(monkeypatch):
     register()
+    calls = {}
+
+    def fake_get_config_dict(config_source, **kwargs):
+        calls["config_source"] = config_source
+        calls["gguf_file"] = kwargs.get("gguf_file")
+        return {"model_type": "qwen3"}, {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module.PretrainedConfig,
+        "get_config_dict",
+        fake_get_config_dict,
+    )
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: "org/repo",
+    )
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "file_or_path_exists",
+        lambda model, filename, revision=None: False,
+    )
 
     model, tokenizer, speculative_config = (
         config_module.maybe_override_with_speculators(
-            model="/tmp/model.gguf",
+            model="org/repo/subdir/model.gguf",
             tokenizer="/tmp/tokenizer",
             trust_remote_code=False,
             revision=None,
@@ -721,9 +744,200 @@ def test_register_skips_speculator_probe_for_gguf():
         )
     )
 
-    assert model == "/tmp/model.gguf"
+    assert calls["config_source"] == "org/repo"
+    assert calls["gguf_file"] == "subdir/model.gguf"
+    assert model == "org/repo/subdir/model.gguf"
     assert tokenizer == "/tmp/tokenizer"
     assert speculative_config == {"foo": "bar"}
+
+
+def test_register_speculator_probe_prefers_sidecar_config(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+    calls = {}
+
+    def fake_get_config_dict(config_source, **kwargs):
+        calls["config_source"] = config_source
+        calls["gguf_file"] = kwargs.get("gguf_file")
+        return {"model_type": "qwen3"}, {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module.PretrainedConfig,
+        "get_config_dict",
+        fake_get_config_dict,
+    )
+
+    model, tokenizer, speculative_config = (
+        config_module.maybe_override_with_speculators(
+            model=str(gguf_path),
+            tokenizer="/tmp/tokenizer",
+            trust_remote_code=False,
+            revision=None,
+            vllm_speculative_config=None,
+            hf_token=None,
+        )
+    )
+
+    assert calls["config_source"] == gguf_path.parent
+    assert calls["gguf_file"] is None
+    assert model == str(gguf_path)
+    assert tokenizer == "/tmp/tokenizer"
+    assert speculative_config is None
+
+
+def test_register_speculator_probe_extracts_config(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "draft.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    captured = {}
+
+    def fake_get_config_dict(config_source, **kwargs):
+        captured["config_source"] = config_source
+        captured["gguf_file"] = kwargs.get("gguf_file")
+        return {
+            "model_type": "qwen3",
+            "speculators_config": {
+                "verifier": {"name_or_path": "verifier/repo"},
+            },
+        }, {}
+
+    class FakeSpeculatorsConfig:
+        @staticmethod
+        def extract_vllm_speculative_config(config_dict):
+            captured["speculators_config"] = config_dict["speculators_config"]
+            return {"draft": "config"}
+
+    monkeypatch.setattr(
+        gguf_plugin_module.PretrainedConfig,
+        "get_config_dict",
+        fake_get_config_dict,
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "vllm.transformers_utils.configs.speculators.base",
+        type(
+            "FakeSpeculatorModule",
+            (),
+            {"SpeculatorsConfig": FakeSpeculatorsConfig},
+        ),
+    )
+
+    model, tokenizer, speculative_config = (
+        config_module.maybe_override_with_speculators(
+            model=str(gguf_path),
+            tokenizer="/tmp/tokenizer",
+            trust_remote_code=False,
+            revision=None,
+            vllm_speculative_config=None,
+            hf_token=None,
+        )
+    )
+
+    assert captured["config_source"] == gguf_path.parent
+    assert captured["gguf_file"] == gguf_path.name
+    assert model == "verifier/repo"
+    assert tokenizer == "verifier/repo"
+    assert speculative_config == {
+        "draft": "config",
+        "model": str(gguf_path),
+    }
+
+
+def test_register_disables_trust_for_gguf_config_redirect(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    captured = {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: "base/repo",
+    )
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(
+        model=str(gguf_path),
+        tokenizer="/tmp/tokenizer",
+        trust_remote_code=True,
+        revision="gguf-revision",
+    )
+    engine_args.create_model_config()
+
+    assert captured["trust_remote_code"] is False
+
+
+def test_register_keeps_trust_for_explicit_gguf_config_path(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    config_path = tmp_path / "config-repo"
+    config_path.mkdir()
+    captured = {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: "base/repo",
+    )
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(
+        model=str(gguf_path),
+        tokenizer="/tmp/tokenizer",
+        trust_remote_code=True,
+        hf_config_path=str(config_path),
+    )
+    engine_args.create_model_config()
+
+    assert captured["trust_remote_code"] is True
+
+
+def test_register_disables_trust_for_gguf_speculator_config(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "draft.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    captured = {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: "base/repo",
+    )
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(
+        model="verifier/repo",
+        tokenizer="verifier/repo",
+        trust_remote_code=True,
+        speculative_config={"model": str(gguf_path)},
+    )
+    engine_args.create_model_config()
+
+    assert captured["trust_remote_code"] is False
+
+
+def test_register_patches_model_config_gguf_helper():
+    register()
+
+    assert (
+        model_config_module.maybe_patch_hf_config_from_gguf
+        is gguf_plugin_module.maybe_patch_hf_config_from_gguf
+    )
 
 
 def test_gguf_qkv_shards_are_padded_in_qkv_order(monkeypatch):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
+import pytest
 import torch
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.model_executor.layers.vocab_parallel_embedding as vocab_embedding_module
@@ -13,10 +16,22 @@ from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
 )
-from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.layers.quantization import (
+    QUANTIZATION_METHODS,
+    get_quantization_config,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.transformers_utils.config import get_config_parser
+
+if "gguf" in QUANTIZATION_METHODS and os.environ.get(
+    "VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE"
+) != "1":
+    pytest.skip(
+        "override-mode plugin tests require vLLM without in-tree GGUF or "
+        "VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE=1",
+        allow_module_level=True,
+    )
 
 import vllm_gguf_plugin.config_parser as gguf_config_parser_module
 import vllm_gguf_plugin.quantization as gguf_quantization

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -49,9 +49,13 @@ from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
 from vllm_gguf_plugin.gguf_tokenizer_builder import build_tokenizer_from_gguf
 from vllm_gguf_plugin.quantization import (
+    GGUFNvFp4LinearMethod,
     GGUFUninitializedParameter,
     GGUFWeightParameter,
     GGUFWeightTypeParameter,
+)
+from vllm_gguf_plugin.quantization.nvfp4 import (
+    split_gguf_nvfp4_weight,
 )
 from vllm_gguf_plugin.weights_adapter import get_weights_adapter
 from vllm_gguf_plugin.weights_adapter.default import (
@@ -494,6 +498,136 @@ def test_qwen35_adapter_dequantizes_forced_token_embedding(monkeypatch):
     assert len(mapped) == 1
     assert mapped[0][0] == f"{module_name}.weight"
     assert torch.equal(mapped[0][1], torch.full((2, 2), 3.0, dtype=torch.float32))
+
+
+def test_split_gguf_nvfp4_weight_to_native_tensors():
+    scale_bytes = torch.tensor([[0x00, 0x38, 0x40, 0x48]], dtype=torch.uint8)
+    packed_values = torch.arange(32, dtype=torch.uint8).reshape(1, 32)
+    qweight = torch.cat((scale_bytes, packed_values), dim=1)
+    grouped = packed_values.reshape(1, 1, 4, 8)
+    values = torch.cat((grouped & 0x0F, grouped >> 4), dim=-1)
+    expected_weight = (values[..., 0::2] | (values[..., 1::2] << 4)).reshape(1, 32)
+
+    weight, weight_scale = split_gguf_nvfp4_weight(qweight)
+
+    assert torch.equal(weight, expected_weight)
+    assert weight_scale.dtype == torch.float8_e4m3fn
+    assert torch.equal(
+        weight_scale.to(torch.float32),
+        torch.tensor([[0.0, 1.0, 2.0, 4.0]], dtype=torch.float32),
+    )
+
+
+def test_default_adapter_maps_nvfp4_qweight_to_native_weights():
+    adapter = GGUFWeightsAdapter(PretrainedConfig(model_type="qwen3"))
+    module_name = "model.layers.0.mlp.down_proj"
+    adapter._native_nvfp4_modules.add(module_name)
+    qweight_type = torch.tensor(
+        int(default_adapter_module.gguf.GGMLQuantizationType.NVFP4)
+    )
+    qweight = torch.cat(
+        (
+            torch.tensor([[0x38, 0x38, 0x38, 0x38]], dtype=torch.uint8),
+            torch.arange(32, dtype=torch.uint8).reshape(1, 32),
+        ),
+        dim=1,
+    )
+
+    mapped = list(
+        adapter.map_weights(
+            [
+                (f"{module_name}.qweight_type", qweight_type),
+                (f"{module_name}.qweight", qweight),
+            ]
+        )
+    )
+
+    assert [name for name, _ in mapped] == [
+        f"{module_name}.weight",
+        f"{module_name}.weight_scale",
+        f"{module_name}.weight_scale_2",
+    ]
+    grouped = qweight[:, 4:].reshape(1, 1, 4, 8)
+    values = torch.cat((grouped & 0x0F, grouped >> 4), dim=-1)
+    expected_weight = (values[..., 0::2] | (values[..., 1::2] << 4)).reshape(1, 32)
+    assert torch.equal(mapped[0][1], expected_weight)
+    assert mapped[1][1].dtype == torch.float8_e4m3fn
+    assert torch.equal(mapped[2][1], torch.tensor(1.0, dtype=torch.float32))
+
+
+def test_default_adapter_discovers_native_nvfp4_modules():
+    modules = GGUFWeightsAdapter.get_native_nvfp4_modules(
+        {
+            "model.layers.0.mlp.down_proj.weight": "NVFP4",
+            "model.embed_tokens.weight": "NVFP4",
+            "lm_head.weight": "NVFP4",
+            "model.layers.0.self_attn.q_proj.weight": "Q4_K",
+        }
+    )
+
+    assert modules == ["model.layers.0.mlp.down_proj"]
+
+
+def test_gguf_config_routes_nvfp4_linear_to_native_method(monkeypatch):
+    register()
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+
+    class FakeNvFp4Kernel:
+        def process_weights_after_loading(self, layer):
+            layer.processed = True
+
+        def apply_weights(self, layer, x, bias=None):
+            return torch.empty(x.shape[0], layer.output_size_per_partition)
+
+    monkeypatch.setattr(
+        "vllm_gguf_plugin.quantization.nvfp4.init_nvfp4_linear_kernel",
+        lambda use_a16=False: FakeNvFp4Kernel(),
+    )
+    quant_config = OOTGGUFConfig(
+        nvfp4_modules=[
+            "model.layers.0.mlp.gate_proj",
+            "model.layers.0.mlp.up_proj",
+        ]
+    )
+    quant_config.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    layer = MergedColumnParallelLinear(
+        input_size=64,
+        output_sizes=[32, 32],
+        bias=False,
+        quant_config=quant_config,
+        prefix="model.layers.0.mlp.gate_up_proj",
+        disable_tp=True,
+    )
+
+    assert "GGUFNvFp4LinearMethod" in WEIGHT_LOADER_V2_SUPPORTED
+    assert isinstance(layer.quant_method, GGUFNvFp4LinearMethod)
+    assert layer.weight.shape == (64, 32)
+    assert layer.weight_scale.shape == (64, 4)
+    assert layer.weight_scale.dtype == torch.float8_e4m3fn
+    assert layer.weight_scale_2.shape == (2,)
+
+    layer.weight_loader_v2(layer.weight, torch.ones((32, 32), dtype=torch.uint8), 0)
+    layer.weight_loader_v2(layer.weight, 2 * torch.ones((32, 32), dtype=torch.uint8), 1)
+    layer.weight_loader_v2(
+        layer.weight_scale,
+        torch.ones((32, 4), dtype=torch.float32).to(torch.float8_e4m3fn),
+        0,
+    )
+    layer.weight_loader_v2(
+        layer.weight_scale,
+        torch.full((32, 4), 2.0, dtype=torch.float32).to(torch.float8_e4m3fn),
+        1,
+    )
+    layer.weight_loader_v2(layer.weight_scale_2, torch.tensor(1.0), 0)
+    layer.weight_loader_v2(layer.weight_scale_2, torch.tensor(1.0), 1)
+    layer.quant_method.process_weights_after_loading(layer)
+
+    assert layer.processed is True
+    assert not hasattr(layer, "weight_scale_2")
+    assert torch.equal(layer.weight_global_scale, torch.tensor(1.0))
 
 
 def test_gguf_linear_uses_weight_loader_v2(monkeypatch):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,16 +17,17 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
 )
 from vllm.model_executor.layers.quantization import (
+    _CUSTOMIZED_METHOD_TO_QUANT_CONFIG,
     QUANTIZATION_METHODS,
-    get_quantization_config,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.transformers_utils.config import get_config_parser
 
-if "gguf" in QUANTIZATION_METHODS and os.environ.get(
-    "VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE"
-) != "1":
+if (
+    "gguf" in QUANTIZATION_METHODS
+    and os.environ.get("VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE") != "1"
+):
     pytest.skip(
         "override-mode plugin tests require vLLM without in-tree GGUF or "
         "VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE=1",
@@ -47,9 +48,7 @@ from vllm_gguf_plugin.quantization import (
 def test_register_overrides_gguf_config():
     register()
 
-    quant_config = get_quantization_config("gguf")
-
-    assert quant_config is OOTGGUFConfig
+    assert _CUSTOMIZED_METHOD_TO_QUANT_CONFIG["gguf"] is OOTGGUFConfig
 
 
 def test_register_overrides_gguf_loader():
@@ -64,7 +63,7 @@ def test_register_is_idempotent():
     register()
     register()
 
-    assert get_quantization_config("gguf") is OOTGGUFConfig
+    assert _CUSTOMIZED_METHOD_TO_QUANT_CONFIG["gguf"] is OOTGGUFConfig
     assert isinstance(
         get_model_loader(LoadConfig(load_format="gguf")), OOTGGUFModelLoader
     )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -936,6 +936,54 @@ def test_register_sets_engine_args_for_gguf_model(monkeypatch):
     assert engine_args.load_format == "gguf"
 
 
+def test_register_defaults_auto_dtype_to_float16_for_blackwell_gguf(monkeypatch):
+    register()
+    captured = {}
+
+    fake_platform = type(
+        "FakePlatform",
+        (),
+        {"has_device_capability": staticmethod(lambda capability: capability == 100)},
+    )
+    monkeypatch.setattr(gguf_plugin_module, "current_platform", fake_platform)
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(model="/tmp/model.gguf")
+
+    engine_args.create_model_config()
+
+    assert captured["dtype"] == "float16"
+    assert engine_args.dtype == "float16"
+
+
+def test_register_preserves_explicit_dtype_for_blackwell_gguf(monkeypatch):
+    register()
+    captured = {}
+
+    fake_platform = type(
+        "FakePlatform",
+        (),
+        {"has_device_capability": staticmethod(lambda capability: capability == 100)},
+    )
+    monkeypatch.setattr(gguf_plugin_module, "current_platform", fake_platform)
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(model="/tmp/model.gguf", dtype="float32")
+
+    engine_args.create_model_config()
+
+    assert captured["dtype"] == "float32"
+    assert engine_args.dtype == "float32"
+
+
 def test_register_sets_embedded_tokenizer_for_local_gguf(tmp_path, monkeypatch):
     register()
     gguf_path = tmp_path / "model.gguf"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -391,6 +391,111 @@ def test_qwen35_adapter_dequantizes_forced_out_proj(monkeypatch):
     assert torch.equal(mapped[0][1], torch.ones((2, 2), dtype=torch.float32))
 
 
+def test_qwen35_prepare_loading_forces_token_embedding_dequant_without_vllm_support(
+    monkeypatch,
+):
+    adapter = Qwen3_5GGUFAdapter(PretrainedConfig(model_type="qwen3_5"))
+    load_spec = type(
+        "LoadSpec",
+        (),
+        {
+            "gguf_to_hf_name_map": {
+                "token_embd.weight": "model.embed_tokens.weight",
+            },
+            "unquantized_modules": [],
+        },
+    )()
+
+    monkeypatch.setattr(
+        GGUFWeightsAdapter,
+        "prepare_loading",
+        lambda self, model_path, model_config: load_spec,
+    )
+    monkeypatch.setattr(
+        qwen3_5_adapter_module,
+        "_qwen3_5_embed_tokens_uses_quant_config",
+        lambda: False,
+    )
+
+    result = adapter.prepare_loading(
+        "model.gguf",
+        type("ModelConfig", (), {})(),
+    )
+
+    assert result is load_spec
+    assert "model.embed_tokens" in adapter._forced_dequantized_modules
+    assert load_spec.unquantized_modules == ["model.embed_tokens"]
+
+
+def test_qwen35_prepare_loading_keeps_token_embedding_quantized_with_vllm_support(
+    monkeypatch,
+):
+    adapter = Qwen3_5GGUFAdapter(PretrainedConfig(model_type="qwen3_5"))
+    load_spec = type(
+        "LoadSpec",
+        (),
+        {
+            "gguf_to_hf_name_map": {
+                "token_embd.weight": "model.embed_tokens.weight",
+            },
+            "unquantized_modules": [],
+        },
+    )()
+
+    monkeypatch.setattr(
+        GGUFWeightsAdapter,
+        "prepare_loading",
+        lambda self, model_path, model_config: load_spec,
+    )
+    monkeypatch.setattr(
+        qwen3_5_adapter_module,
+        "_qwen3_5_embed_tokens_uses_quant_config",
+        lambda: True,
+    )
+
+    result = adapter.prepare_loading(
+        "model.gguf",
+        type("ModelConfig", (), {})(),
+    )
+
+    assert result is load_spec
+    assert "model.embed_tokens" not in adapter._forced_dequantized_modules
+    assert load_spec.unquantized_modules == []
+
+
+def test_qwen35_adapter_dequantizes_forced_token_embedding(monkeypatch):
+    adapter = Qwen3_5GGUFAdapter(PretrainedConfig(model_type="qwen3_5"))
+    module_name = "model.embed_tokens"
+    adapter._forced_dequantized_modules.add(module_name)
+    qweight_type = torch.tensor(
+        int(qwen3_5_adapter_module.gguf.GGMLQuantizationType.Q6_K)
+    )
+    qweight = torch.ones((2, 2), dtype=torch.uint8)
+
+    def fake_dequantize(weight, weight_type):
+        assert weight_type == qwen3_5_adapter_module.gguf.GGMLQuantizationType.Q6_K
+        return torch.full((2, 2), 3.0, dtype=torch.float32).numpy()
+
+    monkeypatch.setattr(
+        qwen3_5_adapter_module.gguf.quants,
+        "dequantize",
+        fake_dequantize,
+    )
+
+    mapped = list(
+        adapter.map_weights(
+            [
+                (f"{module_name}.qweight_type", qweight_type),
+                (f"{module_name}.qweight", qweight),
+            ]
+        )
+    )
+
+    assert len(mapped) == 1
+    assert mapped[0][0] == f"{module_name}.weight"
+    assert torch.equal(mapped[0][1], torch.full((2, 2), 3.0, dtype=torch.float32))
+
+
 def test_gguf_linear_uses_weight_loader_v2(monkeypatch):
     register()
     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1029,6 +1029,35 @@ def test_register_preserves_explicit_dtype_for_blackwell_gguf(monkeypatch):
     assert engine_args.dtype == "float32"
 
 
+def test_register_routes_remote_gguf_base_config_source(monkeypatch):
+    register()
+    captured = {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: "base/repo",
+    )
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(
+        model="org/repo:Q4_K_M",
+        trust_remote_code=True,
+        revision="gguf-revision",
+    )
+
+    engine_args.create_model_config()
+
+    assert captured["model"] == "base/repo"
+    assert captured["model_weights"] == "org/repo:Q4_K_M"
+    assert captured["served_model_name"] == ["org/repo:Q4_K_M"]
+    assert captured["trust_remote_code"] is False
+
+
 def test_register_sets_embedded_tokenizer_for_local_gguf(tmp_path, monkeypatch):
     register()
     gguf_path = tmp_path / "model.gguf"
@@ -1092,6 +1121,11 @@ def test_register_preserves_implicit_gguf_model_for_config_parser(monkeypatch):
         captured.update(kwargs)
         return kwargs
 
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "resolve_gguf_config_source",
+        lambda model, revision=None: model,
+    )
     monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
     engine_args = EngineArgs(model="org/repo/subdir/model.gguf")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
+from pathlib import Path
 
 import pytest
 import torch
@@ -36,10 +38,13 @@ if (
     )
 
 import vllm_gguf_plugin.config_parser as gguf_config_parser_module
+import vllm_gguf_plugin.gguf_tokenizer_builder as gguf_tokenizer_builder_module
 import vllm_gguf_plugin.gguf_utils as gguf_utils_module
+import vllm_gguf_plugin.plugin as gguf_plugin_module
 import vllm_gguf_plugin.quantization as gguf_quantization
 from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
+from vllm_gguf_plugin.gguf_tokenizer_builder import build_tokenizer_from_gguf
 from vllm_gguf_plugin.quantization import (
     GGUFUninitializedParameter,
     GGUFWeightParameter,
@@ -336,6 +341,277 @@ def test_gguf_config_parser_passes_exact_remote_file_when_repo_has_no_config(
     assert config.architectures == ["Qwen3ForCausalLM"]
 
 
+class _FakeGGUFField:
+    def __init__(self, value):
+        self.value = value
+        self.parts = [value]
+
+    def contents(self):
+        return self.value
+
+
+class _FakeGGUFReader:
+    def __init__(self, fields):
+        self.fields = {key: _FakeGGUFField(value) for key, value in fields.items()}
+        self.tensors = []
+
+    def get_field(self, key):
+        return self.fields.get(key)
+
+
+def test_build_tokenizer_from_gguf_metadata_uses_arch_alias_and_cache(
+    tmp_path,
+    monkeypatch,
+):
+    gguf_path = tmp_path / "model.gguf"
+    mmproj_path = tmp_path / "mmproj.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    mmproj_path.write_bytes(b"GGUF")
+    qwen_mm_tokens = [
+        "<|vision_start|>",
+        "<|vision_end|>",
+        "<|vision_pad|>",
+        "<|image_pad|>",
+        "<|video_pad|>",
+    ]
+    qwen_control_tokens = ["<tool_call>", "</tool_call>", "<think>", "</think>"]
+    main_reader = _FakeGGUFReader(
+        {
+            "general.architecture": "qwen35moe",
+            "tokenizer.ggml.tokens": [
+                "<pad>",
+                "<bos>",
+                "<eos>",
+                "hello",
+                *qwen_mm_tokens,
+                *qwen_control_tokens,
+                "[PAD000]",
+            ],
+            "tokenizer.ggml.token_type": [
+                3,
+                3,
+                3,
+                1,
+                *([3] * len(qwen_mm_tokens)),
+                *([4] * len(qwen_control_tokens)),
+                5,
+            ],
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.merges": ["h ello"],
+            "tokenizer.ggml.bos_token_id": 1,
+            "tokenizer.ggml.eos_token_id": 2,
+            "tokenizer.ggml.padding_token_id": 0,
+            "tokenizer.chat_template": "{{ messages }}",
+        }
+    )
+    mmproj_reader = _FakeGGUFReader(
+        {
+            "general.architecture": "clip",
+            "general.type": "mmproj",
+            "clip.vision.patch_size": 16,
+            "clip.vision.spatial_merge_size": 2,
+            "clip.vision.temporal_patch_size": 2,
+        }
+    )
+    calls = []
+
+    class FakeTokenizer:
+        def __init__(self, *args, **kwargs):
+            calls.append(("fast", kwargs))
+            self.chat_template = None
+
+        def save_pretrained(self, path):
+            (path / "tokenizer.json").write_text("{}", encoding="utf-8")
+            (path / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+
+    def fake_convert(architecture, tokenizer_dict):
+        calls.append(("convert", architecture, tokenizer_dict))
+        return object(), {}
+
+    def fake_gguf_reader(path):
+        return mmproj_reader if Path(path) == mmproj_path else main_reader
+
+    monkeypatch.setenv(
+        "VLLM_GGUF_TOKENIZER_CACHE",
+        str(tmp_path / "tokenizer-cache"),
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module.gguf,
+        "GGUFReader",
+        fake_gguf_reader,
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "convert_gguf_tokenizer",
+        fake_convert,
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "PreTrainedTokenizerFast",
+        FakeTokenizer,
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "detect_gguf_multimodal",
+        lambda model: mmproj_path,
+    )
+
+    tokenizer_path = build_tokenizer_from_gguf(gguf_path)
+
+    assert tokenizer_path is not None
+    tokenizer_cache = Path(tokenizer_path)
+    processor_config = json.loads(
+        (tokenizer_cache / "processor_config.json").read_text(encoding="utf-8")
+    )
+    preprocessor_config = json.loads(
+        (tokenizer_cache / "preprocessor_config.json").read_text(encoding="utf-8")
+    )
+    video_config = json.loads(
+        (tokenizer_cache / "video_preprocessor_config.json").read_text(encoding="utf-8")
+    )
+    assert processor_config["processor_class"] == "Qwen3VLProcessor"
+    assert preprocessor_config["image_processor_type"] == "Qwen2VLImageProcessor"
+    assert preprocessor_config["merge_size"] == 2
+    assert video_config["video_processor_type"] == "Qwen3VLVideoProcessor"
+
+    tokenizer_config = json.loads(
+        (tokenizer_cache / "tokenizer_config.json").read_text(encoding="utf-8")
+    )
+    assert tokenizer_config["additional_special_tokens"] == [
+        *qwen_mm_tokens,
+        *qwen_control_tokens,
+    ]
+    assert tokenizer_config["image_token"] == "<|image_pad|>"
+    assert tokenizer_config["video_token"] == "<|video_pad|>"
+    assert calls[0][0] == "convert"
+    assert calls[0][1] == "qwen3_moe"
+    assert calls[1][1]["bos_token"] == "<bos>"
+    assert calls[1][1]["eos_token"] == "<eos>"
+    assert calls[1][1]["pad_token"] == "<pad>"
+
+    def fail_convert(*args, **kwargs):
+        raise AssertionError("cached tokenizer should not call converter again")
+
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "convert_gguf_tokenizer",
+        fail_convert,
+    )
+    (tokenizer_cache / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    (tokenizer_cache / "preprocessor_config.json").unlink()
+    assert build_tokenizer_from_gguf(gguf_path) == tokenizer_path
+    assert (tokenizer_cache / "preprocessor_config.json").is_file()
+
+
+def test_build_tokenizer_from_gguf_prefers_local_config_special_token_ids(
+    tmp_path,
+    monkeypatch,
+):
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "eos_token_id": 4,
+                "pad_token_id": 0,
+                "text_config": {
+                    "bos_token_id": 1,
+                    "eos_token_id": 2,
+                    "pad_token_id": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_reader = _FakeGGUFReader(
+        {
+            "general.architecture": "gemma4",
+            "tokenizer.ggml.tokens": [
+                "<pad>",
+                "<bos>",
+                "<eos>",
+                "hello",
+                "<turn|>",
+            ],
+            "tokenizer.ggml.token_type": [3, 3, 3, 1, 3],
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.merges": ["h ello"],
+            "tokenizer.ggml.bos_token_id": 1,
+            "tokenizer.ggml.eos_token_id": 2,
+            "tokenizer.ggml.padding_token_id": 0,
+        }
+    )
+    calls = []
+
+    class FakeTokenizer:
+        def __init__(self, *args, **kwargs):
+            calls.append(kwargs)
+
+        def save_pretrained(self, path):
+            (path / "tokenizer.json").write_text("{}", encoding="utf-8")
+            (path / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv(
+        "VLLM_GGUF_TOKENIZER_CACHE",
+        str(tmp_path / "tokenizer-cache"),
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module.gguf,
+        "GGUFReader",
+        lambda path: fake_reader,
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "convert_gguf_tokenizer",
+        lambda architecture, tokenizer_dict: (object(), {}),
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "PreTrainedTokenizerFast",
+        FakeTokenizer,
+    )
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "detect_gguf_multimodal",
+        lambda model: None,
+    )
+
+    tokenizer_path = build_tokenizer_from_gguf(gguf_path)
+
+    assert tokenizer_path is not None
+    assert calls[0]["bos_token"] == "<bos>"
+    assert calls[0]["eos_token"] == "<turn|>"
+    assert calls[0]["pad_token"] == "<pad>"
+    tokenizer_config_path = Path(tokenizer_path) / "tokenizer_config.json"
+    tokenizer_config = json.loads(tokenizer_config_path.read_text(encoding="utf-8"))
+    assert tokenizer_config["eos_token"] == "<turn|>"
+    assert "<turn|>" not in tokenizer_config.get("additional_special_tokens", [])
+
+
+def test_build_tokenizer_from_gguf_returns_none_when_cache_key_stat_fails(
+    tmp_path,
+    monkeypatch,
+):
+    gguf_path = tmp_path / "missing.gguf"
+
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module,
+        "check_gguf_file",
+        lambda model: True,
+    )
+
+    def fail_reader(*args, **kwargs):
+        raise AssertionError("stat failure must return before reading GGUF")
+
+    monkeypatch.setattr(
+        gguf_tokenizer_builder_module.gguf,
+        "GGUFReader",
+        fail_reader,
+    )
+
+    assert build_tokenizer_from_gguf(gguf_path) is None
+
+
 def test_register_sets_engine_args_for_gguf_model(monkeypatch):
     register()
     captured = {}
@@ -354,6 +630,61 @@ def test_register_sets_engine_args_for_gguf_model(monkeypatch):
     assert captured["model_weights"] == "/tmp/model.gguf"
     assert captured["quantization"] == "gguf"
     assert engine_args.load_format == "gguf"
+
+
+def test_register_sets_embedded_tokenizer_for_local_gguf(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    captured = {}
+
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "build_tokenizer_from_gguf",
+        lambda model: "/tmp/gguf-tokenizer-cache",
+    )
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(model=str(gguf_path))
+
+    engine_args.create_model_config()
+
+    assert captured["model"] == str(gguf_path)
+    assert captured["model_weights"] == str(gguf_path)
+    assert captured["tokenizer"] == "/tmp/gguf-tokenizer-cache"
+
+
+def test_register_preserves_explicit_tokenizer_for_local_gguf(tmp_path, monkeypatch):
+    register()
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    captured = {}
+
+    def fail_build_tokenizer(model):
+        raise AssertionError("explicit tokenizer must not be replaced")
+
+    monkeypatch.setattr(
+        gguf_plugin_module,
+        "build_tokenizer_from_gguf",
+        fail_build_tokenizer,
+    )
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(model=str(gguf_path), tokenizer="/tmp/tokenizer")
+
+    engine_args.create_model_config()
+
+    assert captured["model"] == "/tmp/tokenizer"
+    assert captured["model_weights"] == str(gguf_path)
+    assert captured["tokenizer"] == "/tmp/tokenizer"
 
 
 def test_register_preserves_implicit_gguf_model_for_config_parser(monkeypatch):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -43,6 +43,8 @@ import vllm_gguf_plugin.gguf_tokenizer_builder as gguf_tokenizer_builder_module
 import vllm_gguf_plugin.gguf_utils as gguf_utils_module
 import vllm_gguf_plugin.plugin as gguf_plugin_module
 import vllm_gguf_plugin.quantization as gguf_quantization
+import vllm_gguf_plugin.weights_adapter.default as default_adapter_module
+import vllm_gguf_plugin.weights_adapter.qwen3_5 as qwen3_5_adapter_module
 from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
 from vllm_gguf_plugin.gguf_tokenizer_builder import build_tokenizer_from_gguf
@@ -51,6 +53,15 @@ from vllm_gguf_plugin.quantization import (
     GGUFWeightParameter,
     GGUFWeightTypeParameter,
 )
+from vllm_gguf_plugin.weights_adapter import get_weights_adapter
+from vllm_gguf_plugin.weights_adapter.default import (
+    GGUFWeightsAdapter,
+    _add_gemma4_gguf_mappings,
+    _add_gemma4_mtp_gguf_mappings,
+    _add_qwen3_5_mtp_gguf_mappings,
+)
+from vllm_gguf_plugin.weights_adapter.gemma4 import Gemma4GGUFAdapter
+from vllm_gguf_plugin.weights_adapter.qwen3_5 import Qwen3_5GGUFAdapter
 
 
 def test_register_overrides_gguf_config():
@@ -86,6 +97,298 @@ def test_oot_config_reuses_in_tree_behavior():
     assert isinstance(quant_config, OOTGGUFConfig)
     assert quant_config.get_name() == "gguf"
     assert repr(quant_config) == "GGUFConfig()"
+
+
+def test_adapter_registry_selects_qwen35_and_gemma4():
+    assert isinstance(
+        get_weights_adapter(PretrainedConfig(model_type="qwen3_5")),
+        Qwen3_5GGUFAdapter,
+    )
+    assert isinstance(
+        get_weights_adapter(PretrainedConfig(model_type="qwen3_5_moe")),
+        Qwen3_5GGUFAdapter,
+    )
+    assert isinstance(
+        get_weights_adapter(PretrainedConfig(model_type="gemma4")),
+        Gemma4GGUFAdapter,
+    )
+    assert isinstance(
+        get_weights_adapter(PretrainedConfig(model_type="gemma4_assistant")),
+        Gemma4GGUFAdapter,
+    )
+
+
+def test_gemma4_adapter_transforms_quantized_moe_names():
+    adapter = Gemma4GGUFAdapter(PretrainedConfig(model_type="gemma4"))
+    qweight = torch.ones((2, 2), dtype=torch.uint8)
+    qweight_type = torch.tensor(2, dtype=torch.uint8)
+
+    mapped = list(
+        adapter.map_weights(
+            [
+                (
+                    "model.layers.0.experts.gate_up_proj.qweight_type",
+                    qweight_type,
+                ),
+                ("model.layers.0.experts.gate_up_proj.qweight", qweight),
+                ("model.layers.0.experts.down_proj.qweight_type", qweight_type),
+                ("model.layers.0.experts.down_proj.qweight", qweight),
+            ]
+        )
+    )
+
+    assert mapped[0][0] == (
+        "model.layers.0.moe.experts.routed_experts.w13_qweight_type"
+    )
+    assert mapped[1][0] == "model.layers.0.moe.experts.routed_experts.w13_qweight"
+    assert mapped[2][0] == "model.layers.0.moe.experts.routed_experts.w2_qweight_type"
+    assert mapped[3][0] == "model.layers.0.moe.experts.routed_experts.w2_qweight"
+
+
+def test_gemma4_adapter_flattens_patch_embed_weight():
+    adapter = Gemma4GGUFAdapter(PretrainedConfig(model_type="gemma4"))
+    weight = torch.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+
+    transformed = adapter.transform_weight(
+        "model.vision_tower.patch_embedder.input_proj.weight",
+        weight,
+    )
+
+    assert transformed.shape == (2, 60)
+    assert torch.equal(transformed, weight.flatten(1))
+
+
+def test_gemma4_gguf_mappings_cover_moe_and_vision():
+    config = PretrainedConfig(model_type="gemma4", num_hidden_layers=2)
+    config.text_config = PretrainedConfig(num_hidden_layers=2)
+    config.vision_config = PretrainedConfig(num_hidden_layers=1)
+    config.architectures = ["Gemma4ForConditionalGeneration"]
+    mapping: dict[str, str] = {}
+    sideload_params = []
+
+    _add_gemma4_gguf_mappings(config, mapping, sideload_params)
+
+    assert mapping["blk.0.ffn_gate_up_exps.weight"] == (
+        "model.language_model.layers.0.experts.gate_up_proj.weight"
+    )
+    assert mapping["blk.1.layer_output_scale.weight"] == (
+        "model.language_model.layers.1.layer_scalar"
+    )
+    assert mapping["v.patch_embd.weight"] == (
+        "model.vision_tower.patch_embedder.input_proj.weight"
+    )
+    assert mapping["v.blk.0.attn_q.weight"] == (
+        "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight"
+    )
+    assert sideload_params[0].fullmatch(
+        "model.language_model.layers.0.experts.gate_up_proj.weight"
+    )
+
+
+def test_gemma4_text_only_does_not_add_vision_mappings():
+    config = PretrainedConfig(
+        architectures=["Gemma4ForCausalLM"],
+        model_type="gemma4",
+        num_hidden_layers=1,
+    )
+    config.text_config = PretrainedConfig(num_hidden_layers=1)
+    config.vision_config = PretrainedConfig(num_hidden_layers=1)
+    mapping: dict[str, str] = {}
+    sideload_params = []
+
+    _add_gemma4_gguf_mappings(config, mapping, sideload_params)
+
+    assert mapping["blk.0.ffn_gate_up_exps.weight"] == (
+        "model.layers.0.experts.gate_up_proj.weight"
+    )
+    assert "v.patch_embd.weight" not in mapping
+
+
+def test_gemma4_mtp_gguf_mappings():
+    config = PretrainedConfig(model_type="gemma4_assistant", num_hidden_layers=2)
+    mapping: dict[str, str] = {}
+
+    _add_gemma4_mtp_gguf_mappings(config, mapping)
+
+    assert mapping["nextn.pre_projection.weight"] == "model.pre_projection.weight"
+    assert mapping["blk.0.attn_q.weight"] == "model.layers.0.self_attn.q_proj.weight"
+    assert "blk.0.attn_k.weight" not in mapping
+    assert mapping["blk.1.layer_output_scale.weight"] == "model.layers.1.layer_scalar"
+
+
+def test_default_adapter_adds_mmproj_only_for_multimodal_layout(tmp_path, monkeypatch):
+    main_path = tmp_path / "model.gguf"
+    mmproj_path = tmp_path / "mmproj.gguf"
+    adapter = GGUFWeightsAdapter(PretrainedConfig(model_type="qwen3_5_moe"))
+    multimodal_config = PretrainedConfig(
+        model_type="qwen3_5_moe",
+        architectures=["Qwen3_5MoeForConditionalGeneration"],
+    )
+    multimodal_config.vision_config = PretrainedConfig()
+    text_config = PretrainedConfig(
+        model_type="qwen3_5",
+        architectures=["Qwen3_5ForCausalLM"],
+    )
+    text_config.vision_config = PretrainedConfig()
+
+    monkeypatch.setattr(
+        default_adapter_module,
+        "detect_gguf_multimodal",
+        lambda model: mmproj_path,
+    )
+
+    assert adapter._get_weight_sources(str(main_path), multimodal_config) == [
+        str(main_path),
+        str(mmproj_path),
+    ]
+    assert adapter._get_weight_sources(str(main_path), text_config) == [str(main_path)]
+
+
+class _FakeTensorNameMap:
+    def get_name(self, name):
+        return None
+
+
+class _FakeModel:
+    def __init__(self, state_names):
+        self._state_names = state_names
+
+    def state_dict(self):
+        return {name: torch.empty((), device="meta") for name in self._state_names}
+
+
+def test_qwen35_multimodal_mapping_includes_visual_and_linear_attention(monkeypatch):
+    config = PretrainedConfig(
+        model_type="qwen3_5",
+        architectures=["Qwen3_5ForConditionalGeneration"],
+    )
+    config.text_config = PretrainedConfig(
+        num_hidden_layers=1,
+        layer_types=["linear_attention"],
+    )
+    config.vision_config = PretrainedConfig(num_hidden_layers=1)
+    model_config = type(
+        "ModelConfig",
+        (),
+        {"hf_config": config, "trust_remote_code": False},
+    )()
+
+    monkeypatch.setattr(default_adapter_module.gguf, "MODEL_ARCH_NAMES", {1: "qwen35"})
+    monkeypatch.setattr(
+        default_adapter_module.gguf,
+        "get_tensor_name_map",
+        lambda arch, num_layers: _FakeTensorNameMap(),
+    )
+    monkeypatch.setattr(
+        default_adapter_module.AutoModelForImageTextToText,
+        "from_config",
+        lambda *args, **kwargs: _FakeModel(
+            ["model.language_model.layers.0.linear_attn.dt_bias"]
+        ),
+    )
+
+    mapping = GGUFWeightsAdapter(config).build_name_map(model_config)
+
+    assert mapping["token_embd.weight"] == "model.language_model.embed_tokens.weight"
+    assert mapping["v.patch_embd.weight.1"] == "model.visual.patch_embed.proj.weight.1"
+    assert mapping["mm.0.weight"] == "model.visual.merger.linear_fc1.weight"
+    assert mapping["blk.0.ssm_dt.bias"] == (
+        "model.language_model.layers.0.linear_attn.dt_bias"
+    )
+
+
+def test_qwen35_mtp_gguf_mappings_use_trunk_layer_count():
+    config = PretrainedConfig(
+        model_type="qwen3_5_moe",
+        num_hidden_layers=40,
+        mtp_num_hidden_layers=2,
+    )
+    mapping: dict[str, str] = {}
+    sideload_params = []
+
+    _add_qwen3_5_mtp_gguf_mappings(config, mapping, sideload_params)
+
+    assert mapping["blk.40.attn_q.weight"] == "mtp.layers.0.self_attn.q_proj.weight"
+    assert mapping["blk.41.attn_k.weight"] == "mtp.layers.1.self_attn.k_proj.weight"
+    assert mapping["blk.40.ffn_gate_inp.weight"] == "mtp.layers.0.mlp.gate.weight"
+    assert mapping["blk.40.nextn.eh_proj.weight"] == "mtp.fc.weight"
+    assert sideload_params[0].fullmatch("mtp.layers.0.mlp.experts.15.gate_proj.weight")
+
+
+def test_qwen35_adapter_combines_split_patch_embed_weight():
+    adapter = Qwen3_5GGUFAdapter(PretrainedConfig(model_type="qwen3_5_moe"))
+    first = torch.ones((2, 3), dtype=torch.float32)
+    second = 2 * torch.ones((2, 3), dtype=torch.float32)
+
+    mapped = list(
+        adapter.map_weights(
+            [
+                ("model.visual.patch_embed.proj.weight", first),
+                ("model.visual.patch_embed.proj.weight.1", second),
+            ]
+        )
+    )
+
+    assert len(mapped) == 1
+    assert mapped[0][0] == "model.visual.patch_embed.proj.weight"
+    assert torch.equal(mapped[0][1], torch.stack((first, second), dim=2))
+
+
+def _qwen35_linear_attn_config():
+    return PretrainedConfig(
+        model_type="qwen3_5_moe",
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_key_head_dim=1,
+        linear_value_head_dim=1,
+    )
+
+
+def test_qwen35_adapter_restores_linear_attention_layout():
+    adapter = Qwen3_5GGUFAdapter(_qwen35_linear_attn_config())
+    # GGUF stores value heads tiled by value-head group; HF expects grouped by
+    # key head. With 2 key heads and 2 value heads per key, [0, 1, 2, 3]
+    # becomes [0, 2, 1, 3].
+    stored_qkv = torch.arange(8, dtype=torch.float32).reshape(8, 1)
+
+    restored = adapter.transform_weight(
+        "model.layers.0.linear_attn.in_proj_qkv.weight",
+        stored_qkv,
+    )
+
+    assert torch.equal(restored.squeeze(-1), torch.tensor([0, 1, 2, 3, 4, 6, 5, 7]))
+
+
+def test_qwen35_adapter_dequantizes_forced_out_proj(monkeypatch):
+    adapter = Qwen3_5GGUFAdapter(_qwen35_linear_attn_config())
+    module_name = "model.layers.0.linear_attn.out_proj"
+    adapter._forced_dequantized_modules.add(module_name)
+    qweight_type = torch.tensor(
+        int(qwen3_5_adapter_module.gguf.GGMLQuantizationType.Q4_0)
+    )
+    qweight = torch.ones((2, 2), dtype=torch.uint8)
+
+    def fake_dequantize(weight, weight_type):
+        assert weight_type == qwen3_5_adapter_module.gguf.GGMLQuantizationType.Q4_0
+        return torch.ones((2, 2), dtype=torch.float32).numpy()
+
+    monkeypatch.setattr(
+        qwen3_5_adapter_module.gguf.quants,
+        "dequantize",
+        fake_dequantize,
+    )
+
+    mapped = list(
+        adapter.map_weights(
+            [
+                (f"{module_name}.qweight_type", qweight_type),
+                (f"{module_name}.qweight", qweight),
+            ]
+        )
+    )
+
+    assert mapped[0][0] == f"{module_name}.weight"
+    assert torch.equal(mapped[0][1], torch.ones((2, 2), dtype=torch.float32))
 
 
 def test_gguf_linear_uses_weight_loader_v2(monkeypatch):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -36,6 +36,7 @@ if (
     )
 
 import vllm_gguf_plugin.config_parser as gguf_config_parser_module
+import vllm_gguf_plugin.gguf_utils as gguf_utils_module
 import vllm_gguf_plugin.quantization as gguf_quantization
 from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
@@ -203,6 +204,7 @@ def test_gguf_config_parser_uses_parent_dir_for_local_file(tmp_path, monkeypatch
     ):
         calls["model"] = model
         calls["trust_remote_code"] = trust_remote_code
+        calls["gguf_file"] = kwargs.get("gguf_file")
         return {}, PretrainedConfig(model_type="qwen3_moe")
 
     monkeypatch.setattr(
@@ -220,8 +222,118 @@ def test_gguf_config_parser_uses_parent_dir_for_local_file(tmp_path, monkeypatch
 
     assert calls["model"] == gguf_path.parent
     assert calls["trust_remote_code"] is False
+    assert calls["gguf_file"] == gguf_path.name
     assert config_dict["norm_topk_prob"] is True
     assert config.architectures == ["Qwen3MoeForCausalLM"]
+
+
+def test_gguf_config_parser_uses_repo_for_exact_remote_file(monkeypatch):
+    calls = {}
+
+    def fake_file_or_path_exists(model, filename, revision):
+        return model == "org/repo" and filename == "config.json"
+
+    def fake_parse(
+        self, model, trust_remote_code, revision=None, code_revision=None, **kwargs
+    ):
+        calls["model"] = model
+        calls["revision"] = revision
+        calls["trust_remote_code"] = trust_remote_code
+        calls["gguf_file"] = kwargs.get("gguf_file")
+        return {}, PretrainedConfig(model_type="qwen3")
+
+    monkeypatch.setattr(
+        gguf_config_parser_module.HFConfigParser,
+        "parse",
+        fake_parse,
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda model, config: config,
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "file_or_path_exists",
+        fake_file_or_path_exists,
+    )
+    monkeypatch.setattr(
+        gguf_utils_module,
+        "file_or_path_exists",
+        fake_file_or_path_exists,
+    )
+    monkeypatch.setattr(
+        gguf_utils_module,
+        "_get_remote_gguf_base_model_ids",
+        lambda repo_id, revision=None: (),
+    )
+
+    config_dict, config = GGUFConfigParser().parse(
+        "org/repo/subdir/model.gguf",
+        trust_remote_code=True,
+        revision="main",
+    )
+
+    assert calls["model"] == "org/repo"
+    assert calls["revision"] == "main"
+    assert calls["trust_remote_code"] is True
+    assert calls["gguf_file"] is None
+    assert config_dict["architectures"] == ["Qwen3ForCausalLM"]
+    assert config.architectures == ["Qwen3ForCausalLM"]
+
+
+def test_gguf_config_parser_passes_exact_remote_file_when_repo_has_no_config(
+    monkeypatch,
+):
+    calls = {}
+
+    def fake_parse(
+        self, model, trust_remote_code, revision=None, code_revision=None, **kwargs
+    ):
+        calls["model"] = model
+        calls["revision"] = revision
+        calls["trust_remote_code"] = trust_remote_code
+        calls["gguf_file"] = kwargs.get("gguf_file")
+        return {}, PretrainedConfig(model_type="qwen3")
+
+    monkeypatch.setattr(
+        gguf_config_parser_module.HFConfigParser,
+        "parse",
+        fake_parse,
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda model, config: config,
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "file_or_path_exists",
+        lambda model, filename, revision: False,
+    )
+    monkeypatch.setattr(
+        gguf_utils_module,
+        "file_or_path_exists",
+        lambda model, filename, revision: False,
+    )
+    monkeypatch.setattr(
+        gguf_utils_module,
+        "_get_remote_gguf_base_model_ids",
+        lambda repo_id, revision=None: (),
+    )
+
+    config_dict, config = GGUFConfigParser().parse(
+        "org/repo/subdir/model.gguf",
+        trust_remote_code=True,
+        revision="main",
+    )
+
+    assert calls["model"] == "org/repo"
+    assert calls["revision"] == "main"
+    assert calls["trust_remote_code"] is True
+    assert calls["gguf_file"] == "subdir/model.gguf"
+    assert config_dict["architectures"] == ["Qwen3ForCausalLM"]
+    assert config.architectures == ["Qwen3ForCausalLM"]
 
 
 def test_register_sets_engine_args_for_gguf_model(monkeypatch):
@@ -240,6 +352,26 @@ def test_register_sets_engine_args_for_gguf_model(monkeypatch):
     assert captured["config_format"] == "gguf"
     assert captured["model"] == "/tmp/tokenizer"
     assert captured["model_weights"] == "/tmp/model.gguf"
+    assert captured["quantization"] == "gguf"
+    assert engine_args.load_format == "gguf"
+
+
+def test_register_preserves_implicit_gguf_model_for_config_parser(monkeypatch):
+    register()
+    captured = {}
+
+    def fake_model_config(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(arg_utils_module, "ModelConfig", fake_model_config)
+    engine_args = EngineArgs(model="org/repo/subdir/model.gguf")
+
+    engine_args.create_model_config()
+
+    assert captured["config_format"] == "gguf"
+    assert captured["model"] == "org/repo/subdir/model.gguf"
+    assert captured["model_weights"] == "org/repo/subdir/model.gguf"
     assert captured["quantization"] == "gguf"
     assert engine_args.load_format == "gguf"
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -428,6 +428,31 @@ def test_gguf_linear_uses_weight_loader_v2(monkeypatch):
     assert layer.qweight_type.shard_weight_type == {0: 3, 1: 4}
 
 
+def test_gguf_weight_type_loader_stores_tuple_shards(monkeypatch):
+    register()
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    quant_config = OOTGGUFConfig.from_config({})
+    layer = MergedColumnParallelLinear(
+        input_size=4,
+        output_sizes=[4, 4],
+        bias=False,
+        quant_config=quant_config,
+        disable_tp=True,
+    )
+
+    layer.qweight_type.weight_loader(
+        layer.qweight_type,
+        torch.tensor(3, dtype=torch.uint8),
+        (0, 1),
+    )
+
+    assert layer.qweight_type.shard_weight_type == {0: 3, 1: 3}
+    assert layer.qweight_type.weight_type == 3
+
+
 def test_gguf_embedding_uses_plugin_weight_loader(monkeypatch):
     monkeypatch.setattr(
         vocab_embedding_module, "get_tensor_model_parallel_rank", lambda: 0

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import torch
 import vllm.engine.arg_utils as arg_utils_module
+import vllm.model_executor.layers.quantization as quantization_module
 import vllm.model_executor.layers.vocab_parallel_embedding as vocab_embedding_module
 import vllm.model_executor.parameter as parameter_module
 import vllm.transformers_utils.config as config_module
@@ -49,6 +50,7 @@ def test_register_overrides_gguf_config():
     register()
 
     assert _CUSTOMIZED_METHOD_TO_QUANT_CONFIG["gguf"] is OOTGGUFConfig
+    assert quantization_module.get_quantization_config("gguf") is OOTGGUFConfig
 
 
 def test_register_overrides_gguf_loader():
@@ -64,6 +66,7 @@ def test_register_is_idempotent():
     register()
 
     assert _CUSTOMIZED_METHOD_TO_QUANT_CONFIG["gguf"] is OOTGGUFConfig
+    assert quantization_module.get_quantization_config("gguf") is OOTGGUFConfig
     assert isinstance(
         get_model_loader(LoadConfig(load_format="gguf")), OOTGGUFModelLoader
     )

--- a/tests/test_safe_registration.py
+++ b/tests/test_safe_registration.py
@@ -77,6 +77,11 @@ def test_register_can_override_in_tree_when_explicit(monkeypatch):
         "register_quantization_config",
         fake_register_quantization_config,
     )
+    monkeypatch.setattr(
+        plugin_module,
+        "_patch_quantization_config_lookup",
+        lambda: calls.append("quant_lookup"),
+    )
     monkeypatch.setattr(plugin_module, "_LOAD_FORMAT_TO_MODEL_LOADER", {})
     monkeypatch.setattr(
         plugin_module,
@@ -105,6 +110,7 @@ def test_register_can_override_in_tree_when_explicit(monkeypatch):
     assert calls == [
         "load",
         ("quant", FakeConfig),
+        "quant_lookup",
         ("loader", FakeLoader),
         ("parser", FakeParser),
         "engine_args",

--- a/tests/test_safe_registration.py
+++ b/tests/test_safe_registration.py
@@ -2,7 +2,6 @@
 
 import sys
 
-import vllm_gguf_plugin
 import vllm_gguf_plugin.plugin as plugin_module
 
 
@@ -73,14 +72,33 @@ def test_register_can_override_in_tree_when_explicit(monkeypatch):
     monkeypatch.setenv("VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE", "1")
     monkeypatch.setattr(plugin_module, "_load_oot_gguf_classes", fake_load)
     monkeypatch.setattr(plugin_module, "QUANTIZATION_METHODS", ["gguf"])
-    monkeypatch.setattr(plugin_module, "get_quantization_config", lambda name: object)
-    monkeypatch.setattr(plugin_module, "register_quantization_config", fake_register_quantization_config)
+    monkeypatch.setattr(
+        plugin_module,
+        "register_quantization_config",
+        fake_register_quantization_config,
+    )
     monkeypatch.setattr(plugin_module, "_LOAD_FORMAT_TO_MODEL_LOADER", {})
-    monkeypatch.setattr(plugin_module, "register_model_loader", fake_register_model_loader)
+    monkeypatch.setattr(
+        plugin_module,
+        "register_model_loader",
+        fake_register_model_loader,
+    )
     monkeypatch.setattr(plugin_module, "get_config_parser", lambda name: None)
-    monkeypatch.setattr(plugin_module, "register_config_parser", fake_register_config_parser)
-    monkeypatch.setattr(plugin_module, "_patch_engine_args", lambda: calls.append("engine_args"))
-    monkeypatch.setattr(plugin_module, "_patch_speculator_probe", lambda: calls.append("speculator"))
+    monkeypatch.setattr(
+        plugin_module,
+        "register_config_parser",
+        fake_register_config_parser,
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "_patch_engine_args",
+        lambda: calls.append("engine_args"),
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "_patch_speculator_probe",
+        lambda: calls.append("speculator"),
+    )
 
     plugin_module.register()
 

--- a/tests/test_safe_registration.py
+++ b/tests/test_safe_registration.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import vllm_gguf_plugin
+import vllm_gguf_plugin.plugin as plugin_module
+
+
+def test_import_does_not_eagerly_import_quantization():
+    assert "vllm_gguf_plugin.quantization.linear" not in sys.modules
+    assert "vllm_gguf_plugin.quantization.fused_moe" not in sys.modules
+
+
+def test_register_noops_when_vllm_already_has_gguf(monkeypatch):
+    imported = False
+
+    def fail_if_loaded():
+        nonlocal imported
+        imported = True
+        raise AssertionError("plugin classes should not load for in-tree GGUF")
+
+    monkeypatch.setattr(plugin_module, "_load_oot_gguf_classes", fail_if_loaded)
+    monkeypatch.setattr(plugin_module, "QUANTIZATION_METHODS", ["gguf"])
+
+    plugin_module.register()
+
+    assert imported is False
+
+
+def test_register_can_override_in_tree_when_explicit(monkeypatch):
+    calls = []
+
+    class FakeConfig:
+        pass
+
+    class FakeParser:
+        pass
+
+    class FakeLoader:
+        pass
+
+    def fake_load():
+        calls.append("load")
+        return FakeConfig, FakeParser, FakeLoader
+
+    def fake_register_quantization_config(name):
+        assert name == "gguf"
+
+        def inner(config):
+            calls.append(("quant", config))
+            return config
+
+        return inner
+
+    def fake_register_model_loader(name):
+        assert name == "gguf"
+
+        def inner(loader):
+            calls.append(("loader", loader))
+            return loader
+
+        return inner
+
+    def fake_register_config_parser(name):
+        assert name == "gguf"
+
+        def inner(parser):
+            calls.append(("parser", parser))
+            return parser
+
+        return inner
+
+    monkeypatch.setenv("VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE", "1")
+    monkeypatch.setattr(plugin_module, "_load_oot_gguf_classes", fake_load)
+    monkeypatch.setattr(plugin_module, "QUANTIZATION_METHODS", ["gguf"])
+    monkeypatch.setattr(plugin_module, "get_quantization_config", lambda name: object)
+    monkeypatch.setattr(plugin_module, "register_quantization_config", fake_register_quantization_config)
+    monkeypatch.setattr(plugin_module, "_LOAD_FORMAT_TO_MODEL_LOADER", {})
+    monkeypatch.setattr(plugin_module, "register_model_loader", fake_register_model_loader)
+    monkeypatch.setattr(plugin_module, "get_config_parser", lambda name: None)
+    monkeypatch.setattr(plugin_module, "register_config_parser", fake_register_config_parser)
+    monkeypatch.setattr(plugin_module, "_patch_engine_args", lambda: calls.append("engine_args"))
+    monkeypatch.setattr(plugin_module, "_patch_speculator_probe", lambda: calls.append("speculator"))
+
+    plugin_module.register()
+
+    assert calls == [
+        "load",
+        ("quant", FakeConfig),
+        ("loader", FakeLoader),
+        ("parser", FakeParser),
+        "engine_args",
+        "speculator",
+    ]

--- a/vllm_gguf_plugin/__init__.py
+++ b/vllm_gguf_plugin/__init__.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from .config_parser import GGUFConfigParser
-from .loader import GGUFModelLoader
-from .plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
-from .quantization import GGUFConfig
+from .plugin import register
 
 __all__ = [
     "GGUFConfigParser",
@@ -13,3 +10,24 @@ __all__ = [
     "OOTGGUFModelLoader",
     "register",
 ]
+
+
+def __getattr__(name: str):
+    if name in {"GGUFConfig", "GGUFConfigParser", "GGUFModelLoader"}:
+        from .plugin import _load_oot_gguf_classes
+
+        gguf_config, gguf_config_parser, gguf_model_loader = _load_oot_gguf_classes()
+        return {
+            "GGUFConfig": gguf_config,
+            "GGUFConfigParser": gguf_config_parser,
+            "GGUFModelLoader": gguf_model_loader,
+        }[name]
+    if name in {"OOTGGUFConfig", "OOTGGUFModelLoader"}:
+        from .plugin import _load_oot_gguf_classes
+
+        gguf_config, _, gguf_model_loader = _load_oot_gguf_classes()
+        return {
+            "OOTGGUFConfig": gguf_config,
+            "OOTGGUFModelLoader": gguf_model_loader,
+        }[name]
+    raise AttributeError(name)

--- a/vllm_gguf_plugin/config_parser.py
+++ b/vllm_gguf_plugin/config_parser.py
@@ -83,12 +83,14 @@ class GGUFConfigParser(ConfigParserBase):
             config_dict["norm_topk_prob"] = True
             config.update({"norm_topk_prob": True})
 
-        if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+        if getattr(config, "architectures", None):
+            config_dict["architectures"] = config.architectures
+        elif config.model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+            model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
+            config_dict["architectures"] = [model_type]
+            config.update({"architectures": [model_type]})
+        else:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
-
-        model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
-        config_dict["architectures"] = [model_type]
-        config.update({"architectures": [model_type]})
 
         if is_gguf(original_model):
             config = maybe_patch_hf_config_from_gguf(str(original_model), config)

--- a/vllm_gguf_plugin/config_parser.py
+++ b/vllm_gguf_plugin/config_parser.py
@@ -4,16 +4,21 @@ from pathlib import Path
 
 from transformers import PretrainedConfig
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+from transformers.utils import CONFIG_NAME as HF_CONFIG_NAME
 from vllm.transformers_utils.config import HFConfigParser
 from vllm.transformers_utils.config_parser_base import ConfigParserBase
+from vllm.transformers_utils.repo_utils import file_or_path_exists
 
 from .gguf_utils import (
     check_gguf_file,
+    get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
     maybe_patch_hf_config_from_gguf,
+    resolve_gguf_config_source,
     split_remote_gguf,
 )
+from .weight_utils import split_remote_gguf_file_ref
 
 
 class GGUFConfigParser(ConfigParserBase):
@@ -26,7 +31,46 @@ class GGUFConfigParser(ConfigParserBase):
         **kwargs,
     ) -> tuple[dict, PretrainedConfig]:
         original_model = model
-        resolved_model = self._resolve_config_source(model)
+        gguf_path = None
+        if (gguf_file := kwargs.pop("gguf_file", None)) is not None:
+            candidate = Path(model) / gguf_file
+            if check_gguf_file(candidate):
+                original_model = candidate
+                gguf_path = candidate
+
+        resolved_model = self._resolve_config_source(model, revision=revision)
+
+        if gguf_path is not None or check_gguf_file(model):
+            gguf_path = gguf_path or Path(model)
+            resolved_model = self._resolve_config_source(
+                gguf_path,
+                revision=revision,
+            )
+            gguf_repo = gguf_path.parent
+            if resolved_model != gguf_repo:
+                trust_remote_code = False
+                revision = None
+            elif not file_or_path_exists(gguf_repo, HF_CONFIG_NAME, revision):
+                kwargs["gguf_file"] = gguf_path.name
+        elif is_remote_gguf(model):
+            repo_id, quant_type = split_remote_gguf(model)
+            if resolved_model != repo_id:
+                trust_remote_code = False
+                revision = None
+            elif not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision):
+                kwargs["gguf_file"] = get_gguf_file_path_from_hf(
+                    repo_id,
+                    quant_type,
+                    revision=revision,
+                )
+        elif (remote_file_ref := split_remote_gguf_file_ref(str(model))) is not None:
+            repo_id, filename = remote_file_ref
+            if resolved_model != repo_id:
+                trust_remote_code = False
+                revision = None
+            elif not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision):
+                kwargs["gguf_file"] = filename
+
         config_dict, config = HFConfigParser().parse(
             resolved_model,
             trust_remote_code=trust_remote_code,
@@ -52,10 +96,8 @@ class GGUFConfigParser(ConfigParserBase):
         return config_dict, config
 
     @staticmethod
-    def _resolve_config_source(model: str | Path) -> str | Path:
-        if check_gguf_file(model):
-            return Path(model).parent
-        if is_remote_gguf(model):
-            repo_id, _ = split_remote_gguf(model)
-            return repo_id
-        return model
+    def _resolve_config_source(
+        model: str | Path,
+        revision: str | None = None,
+    ) -> str | Path:
+        return resolve_gguf_config_source(model, revision=revision)

--- a/vllm_gguf_plugin/gguf_tokenizer_builder.py
+++ b/vllm_gguf_plugin/gguf_tokenizer_builder.py
@@ -1,0 +1,729 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a HF-compatible tokenizer directory from GGUF embedded metadata."""
+
+import hashlib
+import json
+import os
+from contextlib import suppress
+from os import PathLike
+from pathlib import Path
+from shutil import copyfile
+from typing import Any
+
+import gguf
+from transformers import PreTrainedTokenizerFast
+from transformers.integrations.ggml import (
+    GGUF_TOKENIZER_MAPPING,
+    convert_gguf_tokenizer,
+)
+from vllm.logger import init_logger
+
+from .gguf_utils import (
+    _gguf_reader_value,
+    _gguf_scalar_value,
+    check_gguf_file,
+    detect_gguf_multimodal,
+)
+
+logger = init_logger(__name__)
+
+_TOKENIZER_CACHE_ENV = "VLLM_GGUF_TOKENIZER_CACHE"
+_DEFAULT_TOKENIZER_CACHE = "~/.cache/vllm-gguf-plugin/tokenizers"
+_PROCESSOR_SIDECAR_FILES = (
+    "processor_config.json",
+    "preprocessor_config.json",
+    "video_preprocessor_config.json",
+    "image_processor_config.json",
+)
+_PROCESSOR_DEFAULT_SOURCE = (
+    "non-GGUF processor defaults mirrored from Unsloth Qwen3.6/Gemma4 "
+    "GGUF sidecars observed on 2026-06-11; GGUF metadata values take "
+    "precedence when present"
+)
+
+_TOKENIZER_ARCH_ALIASES = {
+    "qwen35": "qwen3",
+    "qwen3_5": "qwen3",
+    "qwen35moe": "qwen3_moe",
+    "qwen3_5_moe": "qwen3_moe",
+    "gemma4": "gemma3_text",
+    "gemma4-assistant": "gemma3_text",
+    "gemma4_assistant": "gemma3_text",
+}
+
+
+def _decode_value(value: Any) -> Any:
+    value = _gguf_scalar_value(value)
+    if isinstance(value, bytes):
+        with suppress(UnicodeDecodeError):
+            return value.decode("utf-8")
+    return value
+
+
+def _decode_sequence(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bytes)):
+        return _decode_value(value)
+    with suppress(AttributeError):
+        value = value.tolist()
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, list):
+        return [_decode_value(item) for item in value]
+    return _decode_value(value)
+
+
+def _gguf_architecture(reader: gguf.GGUFReader) -> str | None:
+    value = _decode_value(_gguf_reader_value(reader, "general.architecture"))
+    return value if isinstance(value, str) else None
+
+
+def _tokenizer_cache_root() -> Path:
+    return Path(
+        os.environ.get(_TOKENIZER_CACHE_ENV, _DEFAULT_TOKENIZER_CACHE)
+    ).expanduser()
+
+
+def _cache_key(model_path: Path) -> str | None:
+    try:
+        stat = model_path.stat()
+    except OSError as e:
+        logger.debug("Failed to stat GGUF tokenizer source %s: %s", model_path, e)
+        return None
+    raw_key = f"{model_path.resolve()}:{stat.st_size}:{stat.st_mtime_ns}"
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()[:24]
+
+
+def _extract_tokenizer_dict(reader: gguf.GGUFReader) -> dict[str, Any]:
+    tokenizer_dict: dict[str, Any] = {}
+    field_mapping = GGUF_TOKENIZER_MAPPING["tokenizer"]
+    for gguf_suffix, hf_name in field_mapping.items():
+        value = _gguf_reader_value(reader, f"tokenizer.{gguf_suffix}")
+        if value is not None:
+            tokenizer_dict[hf_name] = _decode_sequence(value)
+    token_type_value = _gguf_reader_value(reader, "tokenizer.ggml.token_type")
+    if token_type_value is not None:
+        tokenizer_dict["token_type"] = _decode_sequence(token_type_value)
+    return tokenizer_dict
+
+
+def _extract_tokenizer_config(reader: gguf.GGUFReader) -> dict[str, Any]:
+    tokenizer_config: dict[str, Any] = {}
+    field_mapping = GGUF_TOKENIZER_MAPPING["tokenizer_config"]
+    for gguf_suffix, hf_name in field_mapping.items():
+        value = _gguf_reader_value(reader, f"tokenizer.{gguf_suffix}")
+        if value is not None:
+            tokenizer_config[hf_name] = _decode_sequence(value)
+    return tokenizer_config
+
+
+def _token_by_id(tokens: list[Any], token_id: Any) -> str | None:
+    if token_id is None:
+        return None
+    if isinstance(token_id, (list, tuple)):
+        if not token_id:
+            return None
+        token_id = token_id[0]
+    with suppress(TypeError, ValueError, IndexError):
+        token = tokens[int(token_id)]
+        if isinstance(token, str):
+            return token
+    return None
+
+
+def _special_token_kwargs(tokenizer_dict: dict[str, Any]) -> dict[str, str]:
+    tokens = tokenizer_dict.get("tokens")
+    if not isinstance(tokens, list):
+        return {}
+    special_ids = {
+        "bos_token": tokenizer_dict.get("bos_token_id"),
+        "eos_token": tokenizer_dict.get("eos_token_id"),
+        "pad_token": tokenizer_dict.get("pad_token_id"),
+        "unk_token": tokenizer_dict.get("unk_token_id"),
+    }
+    return {
+        key: token
+        for key, token_id in special_ids.items()
+        if (token := _token_by_id(tokens, token_id)) is not None
+    }
+
+
+def _local_config_path(model_path: Path) -> Path | None:
+    """Return the nearest local HF config next to a GGUF file, if present."""
+    for candidate in (model_path.parent, model_path.parent.parent):
+        config_path = candidate / "config.json"
+        if config_path.is_file():
+            return config_path
+    return None
+
+
+def _read_special_token_ids_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        text_config = {}
+
+    special_ids: dict[str, Any] = {}
+    for token_name, config_key in {
+        "bos_token": "bos_token_id",
+        "eos_token": "eos_token_id",
+        "pad_token": "pad_token_id",
+        "unk_token": "unk_token_id",
+    }.items():
+        token_id = config.get(config_key)
+        if token_id is None:
+            token_id = text_config.get(config_key)
+        if token_id is not None:
+            special_ids[token_name] = token_id
+    return special_ids
+
+
+def _local_config_special_token_kwargs(
+    model_path: Path,
+    tokenizer_dict: dict[str, Any],
+) -> dict[str, str]:
+    tokens = tokenizer_dict.get("tokens")
+    if not isinstance(tokens, list):
+        return {}
+
+    config_path = _local_config_path(model_path)
+    if config_path is None:
+        return {}
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Failed to read local GGUF config %s: %s", config_path, e)
+        return {}
+
+    return {
+        token_name: token
+        for token_name, token_id in _read_special_token_ids_from_config(
+            config,
+        ).items()
+        if (token := _token_by_id(tokens, token_id)) is not None
+    }
+
+
+_GEMMA4_MODEL_SPECIFIC_TOKENS = {
+    "audio_token": "<|audio|>",
+    "boa_token": "<|audio>",
+    "boi_token": "<|image>",
+    "eoa_token": "<audio|>",
+    "eoc_token": "<channel|>",
+    "eoi_token": "<image|>",
+    "eot_token": "<turn|>",
+    "escape_token": '<|"|>',
+    "etc_token": "<tool_call|>",
+    "etd_token": "<tool|>",
+    "etr_token": "<tool_response|>",
+    "image_token": "<|image|>",
+    "soc_token": "<|channel>",
+    "sot_token": "<|turn>",
+    "stc_token": "<|tool_call>",
+    "std_token": "<|tool>",
+    "str_token": "<|tool_response>",
+    "think_token": "<|think|>",
+    "video_token": "<|video|>",
+}
+
+_QWEN_MM_SPECIAL_TOKENS = (
+    "<|vision_start|>",
+    "<|vision_end|>",
+    "<|vision_pad|>",
+    "<|image_pad|>",
+    "<|video_pad|>",
+)
+
+
+def _tokens_present(
+    tokenizer_dict: dict[str, Any],
+    candidates: tuple[str, ...],
+) -> list[str]:
+    tokens = tokenizer_dict.get("tokens")
+    if not isinstance(tokens, list):
+        return []
+    token_set = {token for token in tokens if isinstance(token, str)}
+    return [token for token in candidates if token in token_set]
+
+
+def _gemma4_model_specific_special_tokens(
+    tokenizer_dict: dict[str, Any],
+) -> dict[str, str]:
+    return {
+        name: token
+        for name, token in _GEMMA4_MODEL_SPECIFIC_TOKENS.items()
+        if token in _tokens_present(tokenizer_dict, (token,))
+    }
+
+
+def _append_additional_special_tokens(
+    tokenizer_config: dict[str, Any],
+    tokens: list[str],
+) -> bool:
+    if not tokens:
+        return False
+
+    existing = tokenizer_config.get("additional_special_tokens")
+    if existing is None:
+        additional_tokens: list[Any] = []
+    elif isinstance(existing, list):
+        additional_tokens = list(existing)
+    else:
+        additional_tokens = [existing]
+
+    existing_tokens: set[str] = set()
+    for item in additional_tokens:
+        if isinstance(item, str):
+            existing_tokens.add(item)
+        elif isinstance(item, dict) and isinstance(item.get("content"), str):
+            existing_tokens.add(item["content"])
+
+    changed = False
+    for token in tokens:
+        if token in existing_tokens:
+            continue
+        additional_tokens.append(token)
+        existing_tokens.add(token)
+        changed = True
+
+    if changed:
+        tokenizer_config["additional_special_tokens"] = additional_tokens
+    return changed
+
+
+def _remove_additional_special_tokens(
+    tokenizer_config: dict[str, Any],
+    tokens: set[str],
+) -> bool:
+    if not tokens:
+        return False
+
+    existing = tokenizer_config.get("additional_special_tokens")
+    if existing is None:
+        return False
+    additional_tokens = list(existing) if isinstance(existing, list) else [existing]
+
+    filtered_tokens: list[Any] = []
+    changed = False
+    for item in additional_tokens:
+        token = None
+        if isinstance(item, str):
+            token = item
+        elif isinstance(item, dict) and isinstance(item.get("content"), str):
+            token = item["content"]
+        if token in tokens:
+            changed = True
+            continue
+        filtered_tokens.append(item)
+
+    if changed:
+        tokenizer_config["additional_special_tokens"] = filtered_tokens
+    return changed
+
+
+_GGUF_SPECIAL_TOKEN_TYPES = {
+    int(gguf.TokenType.CONTROL),
+    int(gguf.TokenType.USER_DEFINED),
+}
+
+
+def _gguf_special_control_tokens(
+    tokenizer_dict: dict[str, Any],
+    special_token_kwargs: dict[str, str] | None = None,
+) -> list[str]:
+    """Restore GGUF control/user-defined tokens as HF special tokens."""
+    tokens = tokenizer_dict.get("tokens")
+    token_types = tokenizer_dict.get("token_type")
+    if not isinstance(tokens, list) or not isinstance(token_types, list):
+        return []
+
+    named_special_tokens = set(_special_token_kwargs(tokenizer_dict).values())
+    if special_token_kwargs:
+        named_special_tokens.update(special_token_kwargs.values())
+    special_tokens: list[str] = []
+    for token, token_type in zip(tokens, token_types, strict=False):
+        if not isinstance(token, str) or token in named_special_tokens:
+            continue
+        with suppress(TypeError, ValueError):
+            if int(token_type) in _GGUF_SPECIAL_TOKEN_TYPES:
+                special_tokens.append(token)
+    return special_tokens
+
+
+def _patch_tokenizer_config_from_gguf(
+    cache_dir: Path,
+    architecture: str,
+    tokenizer_dict: dict[str, Any],
+    model_path: Path,
+) -> None:
+    tokenizer_config_path = cache_dir / "tokenizer_config.json"
+    if not tokenizer_config_path.is_file():
+        return
+
+    try:
+        tokenizer_config = json.loads(tokenizer_config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Failed to read tokenizer config %s: %s", tokenizer_config_path, e)
+        return
+
+    changed = False
+    special_token_kwargs = _local_config_special_token_kwargs(
+        model_path,
+        tokenizer_dict,
+    )
+    for token_name, token in special_token_kwargs.items():
+        if tokenizer_config.get(token_name) != token:
+            tokenizer_config[token_name] = token
+            changed = True
+    changed |= _remove_additional_special_tokens(
+        tokenizer_config,
+        set(special_token_kwargs.values()),
+    )
+
+    changed |= _append_additional_special_tokens(
+        tokenizer_config,
+        _gguf_special_control_tokens(tokenizer_dict, special_token_kwargs),
+    )
+
+    if architecture in {"gemma4", "gemma4-assistant", "gemma4_assistant"}:
+        model_specific_tokens = _gemma4_model_specific_special_tokens(tokenizer_dict)
+        if model_specific_tokens:
+            tokenizer_config["processor_class"] = "Gemma4Processor"
+            tokenizer_config["model_specific_special_tokens"] = model_specific_tokens
+            for name, token in model_specific_tokens.items():
+                tokenizer_config.setdefault(name, token)
+            tokenizer_config["extra_special_tokens"] = {
+                **(
+                    tokenizer_config["extra_special_tokens"]
+                    if isinstance(tokenizer_config.get("extra_special_tokens"), dict)
+                    else {}
+                ),
+                **model_specific_tokens,
+            }
+            changed = True
+
+    if architecture in {"qwen35", "qwen3_5", "qwen35moe", "qwen3_5_moe"}:
+        mm_tokens = _tokens_present(tokenizer_dict, _QWEN_MM_SPECIAL_TOKENS)
+        changed |= _append_additional_special_tokens(tokenizer_config, mm_tokens)
+        if "<|image_pad|>" in mm_tokens:
+            tokenizer_config.setdefault("image_token", "<|image_pad|>")
+            changed = True
+        if "<|video_pad|>" in mm_tokens:
+            tokenizer_config.setdefault("video_token", "<|video_pad|>")
+            changed = True
+
+    if changed:
+        tokenizer_config_path.write_text(
+            json.dumps(tokenizer_config, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+
+def _read_int(reader: gguf.GGUFReader, key: str) -> int | None:
+    value = _gguf_scalar_value(_gguf_reader_value(reader, key))
+    if value is None:
+        return None
+    with suppress(TypeError, ValueError):
+        return int(value)
+    return None
+
+
+def _copy_local_processor_sidecars(model_path: Path, cache_dir: Path) -> None:
+    """Copy local sidecar files next to the GGUF, without network fallback."""
+    for filename in _PROCESSOR_SIDECAR_FILES:
+        source = model_path.parent / filename
+        target = cache_dir / filename
+        if target.is_file() or not source.is_file():
+            continue
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            copyfile(source, target)
+        except Exception as e:
+            logger.debug("Failed to copy local GGUF sidecar %s: %s", source, e)
+
+
+def _write_json_if_missing(
+    cache_dir: Path,
+    filename: str,
+    data: dict[str, Any],
+) -> None:
+    target = cache_dir / filename
+    if target.is_file():
+        return
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_mmproj_reader(model_path: Path) -> gguf.GGUFReader | None:
+    mmproj_path = detect_gguf_multimodal(str(model_path))
+    if mmproj_path is None:
+        return None
+    try:
+        return gguf.GGUFReader(str(mmproj_path))
+    except Exception as e:
+        logger.debug("Failed to read GGUF mmproj sidecar %s: %s", mmproj_path, e)
+        return None
+
+
+def _qwen_image_processor_config(reader: gguf.GGUFReader) -> dict[str, Any]:
+    # See _PROCESSOR_DEFAULT_SOURCE for the provenance of non-GGUF defaults.
+    return {
+        "do_convert_rgb": True,
+        "do_normalize": True,
+        "do_rescale": True,
+        "do_resize": True,
+        "image_mean": [0.5, 0.5, 0.5],
+        "image_processor_type": "Qwen2VLImageProcessor",
+        "image_std": [0.5, 0.5, 0.5],
+        "merge_size": _read_int(reader, "clip.vision.spatial_merge_size") or 2,
+        "patch_size": _read_int(reader, "clip.vision.patch_size") or 16,
+        "resample": 3,
+        "rescale_factor": 1.0 / 255.0,
+        "size": {
+            "longest_edge": 16777216,
+            "shortest_edge": 65536,
+        },
+        "temporal_patch_size": (
+            _read_int(reader, "clip.vision.temporal_patch_size") or 2
+        ),
+    }
+
+
+def _qwen_video_processor_config(reader: gguf.GGUFReader) -> dict[str, Any]:
+    # See _PROCESSOR_DEFAULT_SOURCE for the provenance of non-GGUF defaults.
+    config = _qwen_image_processor_config(reader)
+    config.update(
+        {
+            "do_sample_frames": True,
+            "fps": 2,
+            "max_frames": 768,
+            "min_frames": 4,
+            "return_metadata": False,
+            "size": {
+                "longest_edge": 25165824,
+                "shortest_edge": 4096,
+            },
+            "video_processor_type": "Qwen3VLVideoProcessor",
+        }
+    )
+    config.pop("image_processor_type", None)
+    return config
+
+
+def _gemma4_image_processor_config(reader: gguf.GGUFReader) -> dict[str, Any]:
+    # See _PROCESSOR_DEFAULT_SOURCE for the provenance of non-GGUF defaults.
+    patch_size = _read_int(reader, "clip.vision.patch_size") or 16
+    image_seq_length = _read_int(reader, "clip.vision.default_output_length") or 280
+    return {
+        "do_convert_rgb": True,
+        "do_normalize": False,
+        "do_rescale": True,
+        "do_resize": True,
+        "image_mean": [0.0, 0.0, 0.0],
+        "image_processor_type": "Gemma4ImageProcessor",
+        "image_seq_length": image_seq_length,
+        "image_std": [1.0, 1.0, 1.0],
+        "max_soft_tokens": image_seq_length,
+        "patch_size": patch_size,
+        "pooling_kernel_size": 3,
+        "resample": 3,
+        "rescale_factor": 1.0 / 255.0,
+    }
+
+
+def _gemma4_video_processor_config(reader: gguf.GGUFReader) -> dict[str, Any]:
+    # See _PROCESSOR_DEFAULT_SOURCE for the provenance of non-GGUF defaults.
+    patch_size = _read_int(reader, "clip.vision.patch_size") or 16
+    return {
+        "do_convert_rgb": True,
+        "do_normalize": True,
+        "do_rescale": True,
+        "do_resize": True,
+        "do_sample_frames": True,
+        "image_mean": [0.0, 0.0, 0.0],
+        "image_std": [1.0, 1.0, 1.0],
+        "max_soft_tokens": 70,
+        "num_frames": 32,
+        "patch_size": patch_size,
+        "pooling_kernel_size": 3,
+        "resample": 3,
+        "rescale_factor": 1.0 / 255.0,
+        "return_metadata": False,
+        "video_processor_type": "Gemma4VideoProcessor",
+    }
+
+
+def _gemma4_feature_extractor_config() -> dict[str, Any]:
+    # See _PROCESSOR_DEFAULT_SOURCE for the provenance of non-GGUF defaults.
+    return {
+        "dither": 0.0,
+        "feature_extractor_type": "Gemma4AudioFeatureExtractor",
+        "feature_size": 128,
+        "fft_length": 512,
+        "fft_overdrive": False,
+        "frame_length": 320,
+        "hop_length": 160,
+        "input_scale_factor": 1.0,
+        "max_frequency": 8000.0,
+        "mel_floor": 0.001,
+        "min_frequency": 0.0,
+        "padding_side": "right",
+        "padding_value": 0.0,
+        "per_bin_mean": None,
+        "per_bin_stddev": None,
+        "preemphasis": 0.0,
+        "preemphasis_htk_flavor": True,
+        "return_attention_mask": True,
+        "sampling_rate": 16000,
+    }
+
+
+def _processor_sidecars_from_metadata(
+    architecture: str,
+    mmproj_reader: gguf.GGUFReader,
+) -> dict[str, dict[str, Any]]:
+    if architecture in {"qwen35", "qwen3_5", "qwen35moe", "qwen3_5_moe"}:
+        image_config = _qwen_image_processor_config(mmproj_reader)
+        video_config = _qwen_video_processor_config(mmproj_reader)
+        return {
+            "processor_config.json": {
+                "image_processor": image_config,
+                "processor_class": "Qwen3VLProcessor",
+                "video_processor": video_config,
+            },
+            "preprocessor_config.json": image_config,
+            "video_preprocessor_config.json": video_config,
+        }
+
+    if architecture == "gemma4":
+        image_config = _gemma4_image_processor_config(mmproj_reader)
+        video_config = _gemma4_video_processor_config(mmproj_reader)
+        return {
+            "processor_config.json": {
+                "audio_ms_per_token": 40,
+                "audio_seq_length": 750,
+                "feature_extractor": _gemma4_feature_extractor_config(),
+                "image_processor": image_config,
+                "image_seq_length": image_config["image_seq_length"],
+                "processor_class": "Gemma4Processor",
+                "video_processor": video_config,
+            },
+            "preprocessor_config.json": image_config,
+            "video_preprocessor_config.json": video_config,
+        }
+
+    return {}
+
+
+def _materialize_processor_sidecars(
+    model_path: Path,
+    cache_dir: Path,
+    architecture: str | None = None,
+) -> None:
+    """Materialize processor sidecars without implicit HF Hub access."""
+    _copy_local_processor_sidecars(model_path, cache_dir)
+    mmproj_reader = _read_mmproj_reader(model_path)
+    if mmproj_reader is None:
+        return
+
+    if architecture is None:
+        try:
+            architecture = _gguf_architecture(gguf.GGUFReader(str(model_path)))
+        except Exception as e:
+            logger.debug("Failed to read GGUF architecture from %s: %s", model_path, e)
+            return
+    if architecture is None:
+        return
+
+    for filename, data in _processor_sidecars_from_metadata(
+        architecture,
+        mmproj_reader,
+    ).items():
+        _write_json_if_missing(cache_dir, filename, data)
+
+
+def _patch_cached_tokenizer_from_gguf(
+    model_path: Path,
+    cache_dir: Path,
+) -> str | None:
+    try:
+        reader = gguf.GGUFReader(str(model_path))
+        architecture = _gguf_architecture(reader)
+        if architecture is None:
+            return None
+        tokenizer_dict = _extract_tokenizer_dict(reader)
+    except Exception as e:
+        logger.debug(
+            "Failed to read cached GGUF tokenizer metadata %s: %s", model_path, e
+        )
+        return None
+
+    _patch_tokenizer_config_from_gguf(
+        cache_dir,
+        architecture,
+        tokenizer_dict,
+        model_path,
+    )
+    _materialize_processor_sidecars(model_path, cache_dir, architecture)
+    return architecture
+
+
+def build_tokenizer_from_gguf(model: str | PathLike) -> str | None:
+    """Materialize a tokenizer directory from GGUF embedded metadata.
+
+    Returns the cache directory path on success. Returns ``None`` if the GGUF
+    tokenizer is unsupported or incomplete, so callers can use existing
+    tokenizer fallback behavior.
+    """
+    model_path = Path(model)
+    if not check_gguf_file(model_path):
+        return None
+
+    cache_key = _cache_key(model_path)
+    if cache_key is None:
+        return None
+    cache_dir = _tokenizer_cache_root() / cache_key
+    if (cache_dir / "tokenizer.json").is_file():
+        _patch_cached_tokenizer_from_gguf(model_path, cache_dir)
+        return str(cache_dir)
+
+    try:
+        reader = gguf.GGUFReader(str(model_path))
+        architecture = _gguf_architecture(reader)
+        if architecture is None:
+            return None
+        tokenizer_architecture = _TOKENIZER_ARCH_ALIASES.get(
+            architecture,
+            architecture,
+        )
+        tokenizer_dict = _extract_tokenizer_dict(reader)
+        tokenizer_config = _extract_tokenizer_config(reader)
+        backend_tokenizer, additional_kwargs = convert_gguf_tokenizer(
+            tokenizer_architecture,
+            tokenizer_dict,
+        )
+        special_token_kwargs = _special_token_kwargs(tokenizer_dict)
+        special_token_kwargs.update(
+            _local_config_special_token_kwargs(model_path, tokenizer_dict)
+        )
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=backend_tokenizer,
+            **additional_kwargs,
+            **special_token_kwargs,
+        )
+        if chat_template := tokenizer_config.get("chat_template"):
+            tokenizer.chat_template = chat_template
+    except Exception as e:
+        logger.debug("Failed to build tokenizer from GGUF %s: %s", model_path, e)
+        return None
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer.save_pretrained(cache_dir)
+    _patch_tokenizer_config_from_gguf(
+        cache_dir,
+        architecture,
+        tokenizer_dict,
+        model_path,
+    )
+    _materialize_processor_sidecars(model_path, cache_dir, architecture)
+    return str(cache_dir)

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -5,6 +5,7 @@
 from functools import cache
 from os import PathLike
 from pathlib import Path
+from typing import Any
 
 import gguf
 import regex as re
@@ -12,9 +13,13 @@ from gguf.constants import Keys, LlamaFileType, VisionProjectorType
 from gguf.quants import GGMLQuantizationType
 from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 from vllm.logger import init_logger
-from vllm.transformers_utils.repo_utils import list_filtered_repo_files
+from vllm.transformers_utils.repo_utils import (
+    file_or_path_exists,
+    hf_api,
+    list_filtered_repo_files,
+)
 
-from .weight_utils import resolve_gguf_file_set
+from .weight_utils import resolve_gguf_file_set, split_remote_gguf_file_ref
 
 logger = init_logger(__name__)
 
@@ -85,6 +90,14 @@ def is_nonstandard_gguf_quant_type(quant_type: str) -> bool:
 # Common suffixes used in GGUF file naming conventions
 # e.g., Q4_K_M, Q3_K_S, Q5_K_L, Q2_K_XL
 _GGUF_QUANT_SUFFIXES = ("_M", "_S", "_L", "_XL", "_XS", "_XXS")
+_HF_CONFIG_FILES = ("config.json",)
+_HF_REPO_ID_PATTERN = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+)
+_HF_REPO_URL_PATTERN = re.compile(
+    r"^https?://huggingface\.co/"
+    r"([a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*)"
+)
 
 
 def is_valid_gguf_quant_type(gguf_quant_type: str) -> bool:
@@ -131,6 +144,161 @@ def split_remote_gguf(model: str | Path) -> tuple[str, str]:
     )
 
 
+def _normalize_base_model_ids(base_model: Any) -> list[str]:
+    if base_model is None:
+        return []
+    if isinstance(base_model, str):
+        return [base_model] if base_model else []
+    if isinstance(base_model, (list, tuple, set)):
+        return [model_id for model_id in base_model if isinstance(model_id, str)]
+    return []
+
+
+def _normalize_hf_repo_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    if value.endswith(".git"):
+        value = value[:-4]
+
+    if _HF_REPO_ID_PATTERN.fullmatch(value):
+        return value
+
+    match = _HF_REPO_URL_PATTERN.match(value)
+    if match:
+        repo_id = match.group(1)
+        if repo_id.endswith(".git"):
+            repo_id = repo_id[:-4]
+        return repo_id
+
+    return None
+
+
+@cache
+def _get_remote_gguf_base_model_ids(
+    repo_id: str,
+    revision: str | None = None,
+) -> tuple[str, ...]:
+    try:
+        info = hf_api().model_info(repo_id, revision=revision)
+    except Exception as e:
+        logger.debug("Failed to inspect GGUF model card for %s: %s", repo_id, e)
+        return ()
+
+    card_data = getattr(info, "card_data", None)
+    base_model = getattr(card_data, "base_model", None)
+    if base_model is None and isinstance(card_data, dict):
+        base_model = card_data.get("base_model")
+
+    base_model_ids: list[str] = []
+    for value in _normalize_base_model_ids(base_model):
+        if normalized_repo_id := _normalize_hf_repo_id(value):
+            base_model_ids.append(normalized_repo_id)
+
+    return tuple(dict.fromkeys(base_model_ids))
+
+
+def _gguf_field_value(field: Any) -> Any:
+    try:
+        return field.contents()
+    except Exception as e:
+        logger.debug("Failed to read GGUF metadata field: %s", e)
+        return None
+
+
+@cache
+def _get_local_gguf_base_model_ids(model: str | Path) -> tuple[str, ...]:
+    try:
+        reader = gguf.GGUFReader(str(model))
+    except Exception as e:
+        logger.debug("Failed to inspect GGUF metadata for %s: %s", model, e)
+        return ()
+
+    base_model_ids: list[str] = []
+    for key, field in reader.fields.items():
+        if not (key.startswith("general.base_model.") and key.endswith(".repo_url")):
+            continue
+        if repo_id := _normalize_hf_repo_id(_gguf_field_value(field)):
+            base_model_ids.append(repo_id)
+
+    return tuple(dict.fromkeys(base_model_ids))
+
+
+def _source_has_any_file(
+    model: str | Path,
+    filenames: tuple[str, ...],
+    revision: str | None = None,
+) -> bool:
+    return any(file_or_path_exists(model, filename, revision) for filename in filenames)
+
+
+def _local_gguf_source_candidates(source: Path) -> tuple[Path, ...]:
+    parent = source.parent
+    if parent == source:
+        return (source,)
+    return (source, parent)
+
+
+def _resolve_gguf_hf_source(
+    model: str | Path,
+    filenames: tuple[str, ...],
+    revision: str | None = None,
+) -> str | Path:
+    local_sources: tuple[Path, ...] = ()
+    remote_file_ref = split_remote_gguf_file_ref(str(model))
+    if is_remote_gguf(model):
+        source: str | Path
+        source, _ = split_remote_gguf(model)
+        is_remote_source = True
+    elif remote_file_ref is not None:
+        source, _ = remote_file_ref
+        is_remote_source = True
+    elif check_gguf_file(model):
+        source = Path(model).parent
+        local_sources = _local_gguf_source_candidates(source)
+        is_remote_source = False
+    else:
+        return model
+
+    for local_source in local_sources:
+        if _source_has_any_file(local_source, filenames, revision=revision):
+            return local_source
+    if not local_sources and _source_has_any_file(source, filenames, revision=revision):
+        return source
+
+    if is_remote_source:
+        base_model_ids = list(
+            _get_remote_gguf_base_model_ids(str(source), revision=revision)
+        )
+    else:
+        base_model_ids = list(_get_local_gguf_base_model_ids(model))
+
+    for base_model in base_model_ids:
+        if _source_has_any_file(base_model, filenames, revision=None):
+            logger.warning_once(
+                "GGUF metadata redirects HF config loading from %s to base "
+                "model '%s'. `trust_remote_code` is not inherited across "
+                "implicit GGUF base-model redirects; pass an explicit "
+                "`--hf-config-path` to opt in for that repository.",
+                model,
+                base_model,
+            )
+            return base_model
+
+    return source
+
+
+def resolve_gguf_config_source(
+    model: str | Path,
+    revision: str | None = None,
+) -> str | Path:
+    """Resolve where a GGUF model should load its HF config from."""
+    if is_gguf(model):
+        return _resolve_gguf_hf_source(model, _HF_CONFIG_FILES, revision=revision)
+    return model
+
+
 def is_local_gguf_quant(model: str | Path) -> bool:
     """Check if the model is a local path with GGUF quant type.
 
@@ -162,6 +330,10 @@ def is_gguf(model: str | Path) -> bool:
 
     # Check if it's a remote GGUF model (repo_id:quant_type format)
     if is_remote_gguf(model):
+        return True
+
+    # Check if it's an exact remote GGUF file reference
+    if split_remote_gguf_file_ref(model) is not None:
         return True
 
     # Check if it's a local dir:quant_type format

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -14,6 +14,8 @@ from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 from vllm.logger import init_logger
 from vllm.transformers_utils.repo_utils import list_filtered_repo_files
 
+from .weight_utils import resolve_gguf_file_set
+
 logger = init_logger(__name__)
 
 
@@ -297,8 +299,11 @@ def extract_lm_head_from_gguf(model_path: str | Path) -> bool:
     if not check_gguf_file(model_path):
         return None
 
-    reader = gguf.GGUFReader(str(model_path))
-    return any(tensor.name == "output.weight" for tensor in reader.tensors)
+    return any(
+        tensor.name == "output.weight"
+        for gguf_file in resolve_gguf_file_set(model_path)
+        for tensor in gguf.GGUFReader(str(gguf_file)).tensors
+    )
 
 
 def maybe_patch_hf_config_from_gguf(

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """GGUF utility functions."""
 
+from contextlib import suppress
 from functools import cache
 from os import PathLike
 from pathlib import Path
@@ -205,6 +206,31 @@ def _gguf_field_value(field: Any) -> Any:
     except Exception as e:
         logger.debug("Failed to read GGUF metadata field: %s", e)
         return None
+
+
+def _gguf_reader_value(reader: gguf.GGUFReader, key: str) -> Any:
+    field = reader.get_field(key)
+    if field is None:
+        return None
+    return _gguf_field_value(field)
+
+
+def _gguf_scalar_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)):
+        return value
+    try:
+        return value.item()
+    except (AttributeError, ValueError, TypeError):
+        pass
+    with suppress(AttributeError):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)):
+        if len(value) != 1:
+            return None
+        return _gguf_scalar_value(value[0])
+    return value
 
 
 @cache

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, cast
 
 import torch
 import torch.nn as nn
-from huggingface_hub import hf_hub_download
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
@@ -16,7 +15,12 @@ from vllm.model_executor.model_loader.utils import (
 )
 from vllm.utils.torch_utils import set_default_torch_dtype
 
-from .weight_utils import download_gguf, resolve_local_gguf
+from .weight_utils import (
+    download_gguf,
+    download_gguf_file,
+    resolve_local_gguf,
+    split_remote_gguf_file_ref,
+)
 from .weights_adapter import get_weights_adapter
 
 if TYPE_CHECKING:
@@ -57,10 +61,15 @@ class GGUFModelLoader(BaseModelLoader):
                 revision=model_config.revision,
                 ignore_patterns=self.load_config.ignore_patterns,
             )
-        # repo id/filename.gguf
-        if "/" in model_name_or_path and model_name_or_path.endswith(".gguf"):
-            repo_id, filename = model_name_or_path.rsplit("/", 1)
-            return hf_hub_download(repo_id=repo_id, filename=filename)
+        remote_file_ref = split_remote_gguf_file_ref(model_name_or_path)
+        if remote_file_ref is not None:
+            repo_id, filename = remote_file_ref
+            return download_gguf_file(
+                repo_id=repo_id,
+                filename=filename,
+                cache_dir=self.load_config.download_dir,
+                revision=model_config.revision,
+            )
 
         raise ValueError(
             f"Unrecognised GGUF reference: {model_name_or_path} "

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import torch
 import torch.nn as nn
@@ -16,9 +16,11 @@ from vllm.model_executor.model_loader.utils import (
 )
 from vllm.utils.torch_utils import set_default_torch_dtype
 
-from .quantization import GGUFConfig
 from .weight_utils import download_gguf, resolve_local_gguf
 from .weights_adapter import get_weights_adapter
+
+if TYPE_CHECKING:
+    from .quantization import GGUFConfig
 
 logger = init_logger(__name__)
 
@@ -88,7 +90,7 @@ class GGUFModelLoader(BaseModelLoader):
         logger.debug(
             "GGUF unquantized modules: %s", adapter.load_spec.unquantized_modules
         )
-        vllm_config.quant_config = cast(GGUFConfig, vllm_config.quant_config)
+        vllm_config.quant_config = cast("GGUFConfig", vllm_config.quant_config)
         vllm_config.quant_config.unquantized_modules.extend(
             adapter.load_spec.unquantized_modules
         )

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -103,6 +103,7 @@ class GGUFModelLoader(BaseModelLoader):
         vllm_config.quant_config.unquantized_modules.extend(
             adapter.load_spec.unquantized_modules
         )
+        vllm_config.quant_config.nvfp4_modules.extend(adapter.load_spec.nvfp4_modules)
 
         target_device = torch.device(device_config.device)
         with set_default_torch_dtype(model_config.dtype):

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -7,20 +7,17 @@ from typing import Any
 
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.transformers_utils.config as config_module
-from vllm.config.load import LoadConfig
 from vllm.engine.arg_utils import EngineArgs
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import (
     QUANTIZATION_METHODS,
-    get_quantization_config,
     register_quantization_config,
 )
 from vllm.model_executor.model_loader import (
     _LOAD_FORMAT_TO_MODEL_LOADER,
-    get_model_loader,
     register_model_loader,
 )
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
-from vllm.logger import init_logger
 
 from .gguf_utils import check_gguf_file, is_gguf, is_remote_gguf, split_remote_gguf
 
@@ -149,15 +146,9 @@ def register() -> None:
 
     GGUFConfig, GGUFConfigParser, GGUFModelLoader = _load_oot_gguf_classes()
 
-    if (
-        "gguf" not in QUANTIZATION_METHODS
-        or get_quantization_config("gguf") is not GGUFConfig
-    ):
-        register_quantization_config("gguf")(GGUFConfig)
+    register_quantization_config("gguf")(GGUFConfig)
 
-    if "gguf" not in _LOAD_FORMAT_TO_MODEL_LOADER or not isinstance(
-        get_model_loader(LoadConfig(load_format="gguf")), GGUFModelLoader
-    ):
+    if _LOAD_FORMAT_TO_MODEL_LOADER.get("gguf") is not GGUFModelLoader:
         register_model_loader("gguf")(GGUFModelLoader)
 
     try:

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from functools import wraps
 from pathlib import Path
+from typing import Any
 
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.transformers_utils.config as config_module
@@ -18,14 +20,46 @@ from vllm.model_executor.model_loader import (
     register_model_loader,
 )
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
+from vllm.logger import init_logger
 
-from .config_parser import GGUFConfigParser
 from .gguf_utils import check_gguf_file, is_gguf, is_remote_gguf, split_remote_gguf
-from .loader import GGUFModelLoader
-from .quantization import GGUFConfig
 
-OOTGGUFConfig = GGUFConfig
-OOTGGUFModelLoader = GGUFModelLoader
+logger = init_logger(__name__)
+
+GGUFConfig: Any | None = None
+GGUFConfigParser: Any | None = None
+GGUFModelLoader: Any | None = None
+OOTGGUFConfig: Any | None = None
+OOTGGUFModelLoader: Any | None = None
+
+
+def _load_oot_gguf_classes() -> tuple[type, type, type]:
+    """Load plugin classes lazily to avoid custom-op registration on import.
+
+    Importing ``vllm_gguf_plugin.quantization`` registers plugin custom ops.
+    On vLLM builds that still include in-tree GGUF, those names already exist
+    and importing the plugin package can fail before ``register()`` has a chance
+    to decide whether the plugin should be active. Keep these imports behind the
+    registration decision.
+    """
+    global GGUFConfig, GGUFConfigParser, GGUFModelLoader
+    global OOTGGUFConfig, OOTGGUFModelLoader
+
+    if GGUFConfig is None:
+        from .config_parser import GGUFConfigParser as _GGUFConfigParser
+        from .loader import GGUFModelLoader as _GGUFModelLoader
+        from .quantization import GGUFConfig as _GGUFConfig
+
+        GGUFConfig = _GGUFConfig
+        GGUFConfigParser = _GGUFConfigParser
+        GGUFModelLoader = _GGUFModelLoader
+        OOTGGUFConfig = _GGUFConfig
+        OOTGGUFModelLoader = _GGUFModelLoader
+
+    assert GGUFConfig is not None
+    assert GGUFConfigParser is not None
+    assert GGUFModelLoader is not None
+    return GGUFConfig, GGUFConfigParser, GGUFModelLoader
 
 
 def _is_gguf_reference(model: str | None) -> bool:
@@ -102,6 +136,19 @@ def _patch_speculator_probe() -> None:
 
 def register() -> None:
     """Register the out-of-tree GGUF integration."""
+    if (
+        "gguf" in QUANTIZATION_METHODS
+        and os.environ.get("VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE") != "1"
+    ):
+        logger.warning(
+            "Skipping vllm-gguf-plugin registration because vLLM already has "
+            "a GGUF quantization method. Set VLLM_GGUF_PLUGIN_OVERRIDE_IN_TREE=1 "
+            "to force plugin registration."
+        )
+        return
+
+    GGUFConfig, GGUFConfigParser, GGUFModelLoader = _load_oot_gguf_classes()
+
     if (
         "gguf" not in QUANTIZATION_METHODS
         or get_quantization_config("gguf") is not GGUFConfig

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -20,7 +20,8 @@ from vllm.model_executor.model_loader import (
 )
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
 
-from .gguf_utils import is_gguf, is_remote_gguf
+from .gguf_tokenizer_builder import build_tokenizer_from_gguf
+from .gguf_utils import check_gguf_file, is_gguf, is_remote_gguf
 
 logger = init_logger(__name__)
 
@@ -115,6 +116,15 @@ def _patch_engine_args() -> None:
     def create_model_config(self, *args, **kwargs):
         if _is_gguf_reference(self.model):
             gguf_model = self.model
+            explicit_tokenizer = (
+                self.tokenizer if isinstance(self.tokenizer, str) else None
+            )
+            if (
+                self.tokenizer is None
+                and check_gguf_file(gguf_model)
+                and (tokenizer_path := build_tokenizer_from_gguf(gguf_model))
+            ):
+                self.tokenizer = tokenizer_path
             if self.quantization is None:
                 self.quantization = "gguf"
             if self.load_format == "auto":
@@ -127,7 +137,7 @@ def _patch_engine_args() -> None:
                 self.served_model_name = [gguf_model]
             config_source = _get_explicit_gguf_config_source(
                 gguf_model,
-                self.tokenizer if isinstance(self.tokenizer, str) else None,
+                explicit_tokenizer,
                 self.hf_config_path,
             )
             if config_source is not None:

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -23,6 +23,7 @@ from vllm.model_executor.model_loader import (
     _LOAD_FORMAT_TO_MODEL_LOADER,
     register_model_loader,
 )
+from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
 from vllm.transformers_utils.repo_utils import file_or_path_exists
 from vllm.transformers_utils.utils import without_trust_remote_code
@@ -140,6 +141,20 @@ def _get_gguf_config_probe_model(engine_args: EngineArgs) -> str | None:
     return None
 
 
+def _maybe_set_blackwell_gguf_dtype(engine_args: EngineArgs) -> None:
+    if engine_args.dtype != "auto":
+        return
+    if not current_platform.has_device_capability(100):
+        return
+
+    logger.warning_once(
+        "Defaulting GGUF `dtype=auto` to `float16` on Blackwell because "
+        "bfloat16 GGUF kernels are disabled for precision issues. Pass an "
+        "explicit `--dtype` to override this default.",
+    )
+    engine_args.dtype = "float16"
+
+
 def _patch_quantization_config_lookup() -> None:
     if getattr(quantization_module, "_gguf_config_lookup_patched", False):
         return
@@ -193,6 +208,7 @@ def _patch_engine_args() -> None:
 
         if _is_gguf_reference(self.model):
             gguf_model = self.model
+            _maybe_set_blackwell_gguf_dtype(self)
             explicit_tokenizer = (
                 self.tokenizer if isinstance(self.tokenizer, str) else None
             )

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -3,11 +3,16 @@
 import os
 import sys
 from functools import wraps
+from pathlib import Path
 from typing import Any
 
+import huggingface_hub
+import vllm.config.model as model_config_module
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.model_executor.layers.quantization as quantization_module
 import vllm.transformers_utils.config as config_module
+from transformers import PretrainedConfig
+from transformers.utils import CONFIG_NAME as HF_CONFIG_NAME
 from vllm.engine.arg_utils import EngineArgs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import (
@@ -19,9 +24,20 @@ from vllm.model_executor.model_loader import (
     register_model_loader,
 )
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
+from vllm.transformers_utils.repo_utils import file_or_path_exists
+from vllm.transformers_utils.utils import without_trust_remote_code
 
 from .gguf_tokenizer_builder import build_tokenizer_from_gguf
-from .gguf_utils import check_gguf_file, is_gguf, is_remote_gguf
+from .gguf_utils import (
+    check_gguf_file,
+    get_gguf_file_path_from_hf,
+    is_gguf,
+    is_remote_gguf,
+    maybe_patch_hf_config_from_gguf,
+    resolve_gguf_config_source,
+    split_remote_gguf,
+)
+from .weight_utils import split_remote_gguf_file_ref
 
 logger = init_logger(__name__)
 
@@ -79,6 +95,51 @@ def _get_explicit_gguf_config_source(
     return None
 
 
+def _uses_gguf_derived_config_source(
+    model: str | None,
+    revision: str | None = None,
+) -> bool:
+    if not _is_gguf_reference(model):
+        return False
+
+    if check_gguf_file(model):
+        gguf_repo = Path(model).parent
+        resolved_source = resolve_gguf_config_source(model, revision=revision)
+        if resolved_source != gguf_repo:
+            return True
+        return not file_or_path_exists(gguf_repo, HF_CONFIG_NAME, revision)
+
+    if is_remote_gguf(model):
+        repo_id, _ = split_remote_gguf(model)
+        resolved_source = resolve_gguf_config_source(model, revision=revision)
+        if resolved_source != repo_id:
+            return True
+        return not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision)
+
+    remote_file_ref = split_remote_gguf_file_ref(str(model))
+    if remote_file_ref is not None:
+        repo_id, _ = remote_file_ref
+        resolved_source = resolve_gguf_config_source(model, revision=revision)
+        if resolved_source != repo_id:
+            return True
+        return not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision)
+
+    return False
+
+
+def _get_gguf_config_probe_model(engine_args: EngineArgs) -> str | None:
+    if _is_gguf_reference(engine_args.model):
+        return engine_args.model
+
+    speculative_config = getattr(engine_args, "speculative_config", None)
+    if isinstance(speculative_config, dict):
+        speculative_model = speculative_config.get("model")
+        if isinstance(speculative_model, str) and _is_gguf_reference(speculative_model):
+            return speculative_model
+
+    return None
+
+
 def _patch_quantization_config_lookup() -> None:
     if getattr(quantization_module, "_gguf_config_lookup_patched", False):
         return
@@ -114,6 +175,22 @@ def _patch_engine_args() -> None:
 
     @wraps(original_create_model_config)
     def create_model_config(self, *args, **kwargs):
+        if (
+            self.trust_remote_code
+            and self.hf_config_path is None
+            and (gguf_config_model := _get_gguf_config_probe_model(self)) is not None
+            and _uses_gguf_derived_config_source(
+                gguf_config_model,
+                revision=self.revision,
+            )
+        ):
+            config_module.logger.warning_once(
+                "Disabling `trust_remote_code` because model config was "
+                "selected from a GGUF-derived config source. Pass an "
+                "explicit `--hf-config-path` to opt in for that repository.",
+            )
+            self.trust_remote_code = False
+
         if _is_gguf_reference(self.model):
             gguf_model = self.model
             explicit_tokenizer = (
@@ -148,6 +225,17 @@ def _patch_engine_args() -> None:
     EngineArgs._gguf_create_model_config_patched = True
 
 
+def _patch_gguf_config_helpers() -> None:
+    if getattr(model_config_module, "_gguf_config_helpers_patched", False):
+        return
+
+    # ModelConfig imports this helper by value, so update that binding too.
+    model_config_module.maybe_patch_hf_config_from_gguf = (
+        maybe_patch_hf_config_from_gguf
+    )
+    model_config_module._gguf_config_helpers_patched = True
+
+
 def _patch_speculator_probe() -> None:
     if getattr(arg_utils_module, "_gguf_speculator_probe_patched", False):
         return
@@ -155,10 +243,90 @@ def _patch_speculator_probe() -> None:
     original_maybe_override = arg_utils_module.maybe_override_with_speculators
 
     @wraps(original_maybe_override)
-    def maybe_override_with_speculators(model, tokenizer, *args, **kwargs):
-        if _is_gguf_reference(model):
-            return model, tokenizer, kwargs.get("vllm_speculative_config")
-        return original_maybe_override(model, tokenizer, *args, **kwargs)
+    def maybe_override_with_speculators(
+        model,
+        tokenizer,
+        trust_remote_code,
+        revision=None,
+        hf_config_path=None,
+        vllm_speculative_config=None,
+        hf_token=None,
+        **kwargs,
+    ):
+        if not _is_gguf_reference(model):
+            return original_maybe_override(
+                model=model,
+                tokenizer=tokenizer,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                hf_config_path=hf_config_path,
+                vllm_speculative_config=vllm_speculative_config,
+                hf_token=hf_token,
+                **kwargs,
+            )
+
+        remote_file_ref = split_remote_gguf_file_ref(str(model))
+        if check_gguf_file(model):
+            if hf_config_path is None:
+                gguf_repo = Path(model).parent
+                gguf_model_repo = resolve_gguf_config_source(
+                    model,
+                    revision=revision,
+                )
+                if gguf_model_repo != gguf_repo:
+                    revision = None
+                elif not file_or_path_exists(
+                    gguf_repo,
+                    HF_CONFIG_NAME,
+                    revision=revision,
+                ):
+                    kwargs["gguf_file"] = Path(model).name
+            else:
+                gguf_model_repo = Path(model).parent
+        elif is_remote_gguf(model):
+            repo_id, quant_type = split_remote_gguf(model)
+            gguf_model_repo = resolve_gguf_config_source(model, revision=revision)
+            if gguf_model_repo != repo_id:
+                revision = None
+            elif not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision=revision):
+                kwargs["gguf_file"] = get_gguf_file_path_from_hf(
+                    repo_id,
+                    quant_type,
+                    revision=revision,
+                )
+        elif remote_file_ref is not None:
+            repo_id, filename = remote_file_ref
+            gguf_model_repo = resolve_gguf_config_source(model, revision=revision)
+            if gguf_model_repo != repo_id:
+                revision = None
+            elif not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision=revision):
+                kwargs["gguf_file"] = filename
+        else:
+            return model, tokenizer, vllm_speculative_config
+
+        kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
+        config_source = hf_config_path or gguf_model_repo
+        config_dict, _ = PretrainedConfig.get_config_dict(
+            config_source,
+            revision=revision,
+            token=hf_token,
+            **without_trust_remote_code(kwargs),
+        )
+        speculators_config = config_dict.get("speculators_config")
+        if speculators_config is None:
+            return model, tokenizer, vllm_speculative_config
+
+        from vllm.transformers_utils.configs.speculators.base import (
+            SpeculatorsConfig,
+        )
+
+        speculative_config = SpeculatorsConfig.extract_vllm_speculative_config(
+            config_dict=config_dict
+        )
+        speculative_config["model"] = model
+
+        verifier_model = speculators_config["verifier"]["name_or_path"]
+        return verifier_model, verifier_model, speculative_config
 
     arg_utils_module.maybe_override_with_speculators = maybe_override_with_speculators
     config_module.maybe_override_with_speculators = maybe_override_with_speculators
@@ -193,5 +361,6 @@ def register() -> None:
         parser = None
     if not isinstance(parser, GGUFConfigParser):
         register_config_parser("gguf")(GGUFConfigParser)
+    _patch_gguf_config_helpers()
     _patch_engine_args()
     _patch_speculator_probe()

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -128,6 +128,25 @@ def _uses_gguf_derived_config_source(
     return False
 
 
+def _get_implicit_gguf_config_source(
+    model: str,
+    revision: str | None = None,
+) -> str | None:
+    if check_gguf_file(model):
+        gguf_source: str | Path = Path(model).parent
+    elif is_remote_gguf(model):
+        gguf_source, _ = split_remote_gguf(model)
+    elif (remote_file_ref := split_remote_gguf_file_ref(str(model))) is not None:
+        gguf_source, _ = remote_file_ref
+    else:
+        return None
+
+    resolved_source = resolve_gguf_config_source(model, revision=revision)
+    if resolved_source == gguf_source:
+        return None
+    return str(resolved_source)
+
+
 def _get_gguf_config_probe_model(engine_args: EngineArgs) -> str | None:
     if _is_gguf_reference(engine_args.model):
         return engine_args.model
@@ -233,6 +252,11 @@ def _patch_engine_args() -> None:
                 explicit_tokenizer,
                 self.hf_config_path,
             )
+            if config_source is None:
+                config_source = _get_implicit_gguf_config_source(
+                    gguf_model,
+                    revision=self.revision,
+                )
             if config_source is not None:
                 self.model = config_source
         return original_create_model_config(self, *args, **kwargs)

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -3,7 +3,6 @@
 import os
 import sys
 from functools import wraps
-from pathlib import Path
 from typing import Any
 
 import vllm.engine.arg_utils as arg_utils_module
@@ -21,7 +20,7 @@ from vllm.model_executor.model_loader import (
 )
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
 
-from .gguf_utils import check_gguf_file, is_gguf, is_remote_gguf, split_remote_gguf
+from .gguf_utils import is_gguf, is_remote_gguf
 
 logger = init_logger(__name__)
 
@@ -67,21 +66,16 @@ def _is_gguf_reference(model: str | None) -> bool:
     return model.endswith(".gguf") or is_remote_gguf(model) or is_gguf(model)
 
 
-def _get_gguf_config_source(
+def _get_explicit_gguf_config_source(
     model: str,
     tokenizer: str | None,
     hf_config_path: str | None,
-) -> str:
+) -> str | None:
     if hf_config_path is not None:
         return hf_config_path
     if tokenizer is not None and not _is_gguf_reference(tokenizer):
         return tokenizer
-    if is_remote_gguf(model):
-        repo_id, _ = split_remote_gguf(model)
-        return repo_id
-    if check_gguf_file(model):
-        return str(Path(model).parent)
-    return model
+    return None
 
 
 def _patch_quantization_config_lookup() -> None:
@@ -131,11 +125,13 @@ def _patch_engine_args() -> None:
                 self.model_weights = gguf_model
             if self.served_model_name is None:
                 self.served_model_name = [gguf_model]
-            self.model = _get_gguf_config_source(
+            config_source = _get_explicit_gguf_config_source(
                 gguf_model,
                 self.tokenizer if isinstance(self.tokenizer, str) else None,
                 self.hf_config_path,
             )
+            if config_source is not None:
+                self.model = config_source
         return original_create_model_config(self, *args, **kwargs)
 
     EngineArgs.create_model_config = create_model_config

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import sys
 from functools import wraps
 from pathlib import Path
 from typing import Any
 
 import vllm.engine.arg_utils as arg_utils_module
+import vllm.model_executor.layers.quantization as quantization_module
 import vllm.transformers_utils.config as config_module
 from vllm.engine.arg_utils import EngineArgs
 from vllm.logger import init_logger
@@ -82,6 +84,33 @@ def _get_gguf_config_source(
     return model
 
 
+def _patch_quantization_config_lookup() -> None:
+    if getattr(quantization_module, "_gguf_config_lookup_patched", False):
+        return
+
+    assert GGUFConfig is not None
+    original_get_quantization_config = quantization_module.get_quantization_config
+
+    @wraps(original_get_quantization_config)
+    def get_quantization_config(quantization: str):
+        if quantization == "gguf":
+            return GGUFConfig
+        return original_get_quantization_config(quantization)
+
+    quantization_module.get_quantization_config = get_quantization_config
+
+    for module_name in ("vllm.model_executor.model_loader.weight_utils",):
+        module = sys.modules.get(module_name)
+        if (
+            module is not None
+            and getattr(module, "get_quantization_config", None)
+            is original_get_quantization_config
+        ):
+            module.get_quantization_config = get_quantization_config
+
+    quantization_module._gguf_config_lookup_patched = True
+
+
 def _patch_engine_args() -> None:
     if getattr(EngineArgs, "_gguf_create_model_config_patched", False):
         return
@@ -147,6 +176,7 @@ def register() -> None:
     GGUFConfig, GGUFConfigParser, GGUFModelLoader = _load_oot_gguf_classes()
 
     register_quantization_config("gguf")(GGUFConfig)
+    _patch_quantization_config_lookup()
 
     if _LOAD_FORMAT_TO_MODEL_LOADER.get("gguf") is not GGUFModelLoader:
         register_model_loader("gguf")(GGUFModelLoader)

--- a/vllm_gguf_plugin/quantization/__init__.py
+++ b/vllm_gguf_plugin/quantization/__init__.py
@@ -1,6 +1,7 @@
 from .config import GGUFConfig
 from .fused_moe import GGUFMoEMethod, fused_moe_gguf
 from .linear import GGUFLinearMethod, fused_mul_mat_gguf
+from .nvfp4 import GGUFNvFp4LinearMethod
 from .params import (
     GGUFUninitializedParameter,
     GGUFUninitializedWeightParameter,
@@ -26,6 +27,7 @@ __all__ = [
     "GGUFEmbeddingMethod",
     "GGUFLinearMethod",
     "GGUFMoEMethod",
+    "GGUFNvFp4LinearMethod",
     "GGUFUninitializedParameter",
     "GGUFUninitializedWeightParameter",
     "GGUFUninitializedWeightTypeParameter",

--- a/vllm_gguf_plugin/quantization/config.py
+++ b/vllm_gguf_plugin/quantization/config.py
@@ -4,6 +4,7 @@
 from typing import TYPE_CHECKING, Any
 
 import torch
+
 try:
     from vllm.model_executor.layers.fused_moe import RoutedExperts
 except ImportError:
@@ -33,9 +34,14 @@ if TYPE_CHECKING:
 class GGUFConfig(QuantizationConfig):
     """Config class for GGUF."""
 
-    def __init__(self, unquantized_modules: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        unquantized_modules: list[str] | None = None,
+        nvfp4_modules: list[str] | None = None,
+    ) -> None:
         super().__init__()
         self.unquantized_modules = unquantized_modules or []
+        self.nvfp4_modules = nvfp4_modules or []
 
     def __repr__(self) -> str:
         return "GGUFConfig()"
@@ -78,6 +84,7 @@ class GGUFConfig(QuantizationConfig):
     ) -> "QuantizeMethodBase | None":
         from .fused_moe import GGUFMoEMethod
         from .linear import GGUFLinearMethod
+        from .nvfp4 import GGUFNvFp4LinearMethod
         from .vocal_embeds import GGUFEmbeddingMethod
 
         if isinstance(layer, LinearBase):
@@ -85,6 +92,10 @@ class GGUFConfig(QuantizationConfig):
                 prefix, self.unquantized_modules, self.packed_modules_mapping
             ):
                 return UnquantizedLinearMethod()
+            if is_layer_skipped_gguf(
+                prefix, self.nvfp4_modules, self.packed_modules_mapping
+            ):
+                return GGUFNvFp4LinearMethod(self)
             return GGUFLinearMethod(self)
         if isinstance(layer, VocabParallelEmbedding):
             if is_layer_skipped_gguf(
@@ -108,3 +119,5 @@ class GGUFConfig(QuantizationConfig):
             self.unquantized_modules = hf_to_vllm_mapper.apply_list(
                 self.unquantized_modules
             )
+        if self.nvfp4_modules is not None:
+            self.nvfp4_modules = hf_to_vllm_mapper.apply_list(self.nvfp4_modules)

--- a/vllm_gguf_plugin/quantization/config.py
+++ b/vllm_gguf_plugin/quantization/config.py
@@ -4,7 +4,10 @@
 from typing import TYPE_CHECKING, Any
 
 import torch
-from vllm.model_executor.layers.fused_moe import RoutedExperts
+try:
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+except ImportError:
+    from vllm.model_executor.layers.fused_moe import FusedMoE as RoutedExperts
 from vllm.model_executor.layers.linear import (
     LinearBase,
     UnquantizedLinearMethod,

--- a/vllm_gguf_plugin/quantization/custom_ops.py
+++ b/vllm_gguf_plugin/quantization/custom_ops.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def register_or_get_vllm_custom_op(
+    *,
+    op_name: str,
+    op_func: Callable[..., Any],
+    fake_impl: Callable[..., Any],
+) -> Any:
+    """Register a vLLM custom op, or reuse an identical pre-existing op.
+
+    vLLM builds that still carry in-tree GGUF may have already registered the
+    same `torch.ops.vllm` operator names. Reusing that operator keeps explicit
+    override-mode smoke tests possible without weakening the default safe no-op
+    behavior on in-tree builds.
+    """
+    try:
+        direct_register_custom_op(
+            op_name=op_name,
+            op_func=op_func,
+            fake_impl=fake_impl,
+        )
+    except RuntimeError as exc:
+        if (
+            "same name and overload name" not in str(exc)
+            and "already" not in str(exc).lower()
+        ) or not hasattr(torch.ops.vllm, op_name):
+            raise
+    return getattr(torch.ops.vllm, op_name)

--- a/vllm_gguf_plugin/quantization/fused_moe.py
+++ b/vllm_gguf_plugin/quantization/fused_moe.py
@@ -4,9 +4,10 @@
 from functools import partial
 
 import torch
-from vllm.model_executor.layers.fused_moe import (
-    RoutedExperts,
-)
+try:
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+except ImportError:
+    from vllm.model_executor.layers.fused_moe import FusedMoE as RoutedExperts
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
     apply_moe_activation,
@@ -19,9 +20,9 @@ from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.utils.torch_utils import direct_register_custom_op
 
 from .. import ops
+from .custom_ops import register_or_get_vllm_custom_op
 from .params import (
     GGUFUninitializedWeightParameter,
     GGUFUninitializedWeightTypeParameter,
@@ -147,15 +148,11 @@ def _fused_moe_gguf_fake(
     return torch.empty_like(x)
 
 
-try:
-    direct_register_custom_op(
-        op_name="_fused_moe_gguf",
-        op_func=_fused_moe_gguf,
-        fake_impl=_fused_moe_gguf_fake,
-    )
-    fused_moe_gguf = torch.ops.vllm._fused_moe_gguf
-except AttributeError as error:
-    raise error
+fused_moe_gguf = register_or_get_vllm_custom_op(
+    op_name="_fused_moe_gguf",
+    op_func=_fused_moe_gguf,
+    fake_impl=_fused_moe_gguf_fake,
+)
 
 
 class GGUFMoEMethod(FusedMoEMethodBase):

--- a/vllm_gguf_plugin/quantization/linear.py
+++ b/vllm_gguf_plugin/quantization/linear.py
@@ -9,9 +9,9 @@ from vllm.model_executor.layers.linear import (
     register_weight_loader_v2_supported_method,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.utils.torch_utils import direct_register_custom_op
 
 from .. import ops
+from .custom_ops import register_or_get_vllm_custom_op
 from .params import (
     GGUFUninitializedWeightParameter,
     GGUFUninitializedWeightTypeParameter,
@@ -65,15 +65,11 @@ def _fused_mul_mat_gguf_fake(
     return torch.empty(x.shape[0], qweight.shape[0], dtype=x.dtype, device=x.device)
 
 
-try:
-    direct_register_custom_op(
-        op_name="_fused_mul_mat_gguf",
-        op_func=_fused_mul_mat_gguf,
-        fake_impl=_fused_mul_mat_gguf_fake,
-    )
-    fused_mul_mat_gguf = torch.ops.vllm._fused_mul_mat_gguf
-except AttributeError as error:
-    raise error
+fused_mul_mat_gguf = register_or_get_vllm_custom_op(
+    op_name="_fused_mul_mat_gguf",
+    op_func=_fused_mul_mat_gguf,
+    fake_impl=_fused_mul_mat_gguf_fake,
+)
 
 
 @register_weight_loader_v2_supported_method

--- a/vllm_gguf_plugin/quantization/nvfp4.py
+++ b/vllm_gguf_plugin/quantization/nvfp4.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch.nn.parameter import Parameter
+from vllm.model_executor.kernels.linear import init_nvfp4_linear_kernel
+from vllm.model_executor.layers.linear import (
+    LinearMethodBase,
+    register_weight_loader_v2_supported_method,
+)
+from vllm.model_executor.parameter import (
+    GroupQuantScaleParameter,
+    ModelWeightParameter,
+    PerTensorScaleParameter,
+)
+
+GGUF_NVFP4_BLOCK_SIZE = 64
+GGUF_NVFP4_BLOCK_BYTES = 36
+GGUF_NVFP4_SCALE_BYTES = 4
+GGUF_NVFP4_GROUP_SIZE = 16
+
+
+def _as_nvfp4_blocks(qweight: torch.Tensor) -> torch.Tensor:
+    if qweight.dtype != torch.uint8:
+        qweight = qweight.view(torch.uint8)
+    if qweight.ndim == 3:
+        if qweight.shape[-1] != GGUF_NVFP4_BLOCK_BYTES:
+            raise ValueError(
+                "Expected GGUF NVFP4 block dimension to be "
+                f"{GGUF_NVFP4_BLOCK_BYTES}, got {qweight.shape[-1]}."
+            )
+        return qweight.contiguous()
+    if qweight.ndim != 2:
+        raise ValueError(
+            "Expected a 2-D row-packed or 3-D block-packed GGUF NVFP4 tensor, "
+            f"got {qweight.ndim} dimensions."
+        )
+    if qweight.shape[1] % GGUF_NVFP4_BLOCK_BYTES != 0:
+        raise ValueError(
+            "Expected GGUF NVFP4 row byte width to be divisible by "
+            f"{GGUF_NVFP4_BLOCK_BYTES}, got {qweight.shape[1]}."
+        )
+    blocks_per_row = qweight.shape[1] // GGUF_NVFP4_BLOCK_BYTES
+    return qweight.reshape(qweight.shape[0], blocks_per_row, GGUF_NVFP4_BLOCK_BYTES)
+
+
+def gguf_ue4m3_to_fp8_e4m3fn(scale_bytes: torch.Tensor) -> torch.Tensor:
+    """Decode GGUF UE4M3 scales and re-encode as torch FP8 E4M3FN."""
+    scale_bytes = scale_bytes.to(torch.uint8)
+    exp = ((scale_bytes >> 3) & 0x0F).to(torch.int32)
+    man = (scale_bytes & 0x07).to(torch.float32)
+    raw = torch.where(
+        exp == 0,
+        man * (2.0**-9),
+        (1.0 + man / 8.0) * torch.pow(2.0, exp.to(torch.float32) - 7.0),
+    )
+    scale = torch.where(
+        (scale_bytes == 0) | (scale_bytes == 0x7F),
+        torch.zeros_like(raw),
+        raw,
+    )
+    return scale.to(torch.float8_e4m3fn)
+
+
+def split_gguf_nvfp4_weight(qweight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split one GGUF NVFP4 tensor into vLLM native weight and scale tensors."""
+    blocks = _as_nvfp4_blocks(qweight)
+    rows, blocks_per_row, _ = blocks.shape
+    scale_bytes = blocks[..., :GGUF_NVFP4_SCALE_BYTES]
+    packed_values = blocks[..., GGUF_NVFP4_SCALE_BYTES:].reshape(
+        rows, blocks_per_row, GGUF_NVFP4_SCALE_BYTES, 8
+    )
+    low = packed_values & 0x0F
+    high = packed_values >> 4
+    values = torch.cat((low, high), dim=-1)
+    packed_values = values[..., 0::2] | (values[..., 1::2] << 4)
+
+    weight = packed_values.reshape(rows, blocks_per_row * (GGUF_NVFP4_BLOCK_SIZE // 2))
+    weight_scale = gguf_ue4m3_to_fp8_e4m3fn(
+        scale_bytes.reshape(rows, blocks_per_row * GGUF_NVFP4_SCALE_BYTES)
+    )
+    return weight.contiguous(), weight_scale.contiguous()
+
+
+def iter_gguf_nvfp4_native_weights(
+    module_name: str,
+    qweight: torch.Tensor,
+) -> list[tuple[str, torch.Tensor]]:
+    weight, weight_scale = split_gguf_nvfp4_weight(qweight)
+    return [
+        (f"{module_name}.weight", weight),
+        (f"{module_name}.weight_scale", weight_scale),
+        (f"{module_name}.weight_scale_2", torch.tensor(1.0, dtype=torch.float32)),
+    ]
+
+
+@register_weight_loader_v2_supported_method
+class GGUFNvFp4LinearMethod(LinearMethodBase):
+    """Native vLLM NVFP4 W4A16 linear method for GGUF NVFP4 tensors."""
+
+    def __init__(self, quant_config):
+        self.quant_config = quant_config
+        self.group_size = GGUF_NVFP4_GROUP_SIZE
+        self.kernel = init_nvfp4_linear_kernel(use_a16=True)
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        del input_size, output_size
+        if input_size_per_partition % self.group_size != 0:
+            raise ValueError(
+                "GGUF NVFP4 input feature size must be divisible by "
+                f"{self.group_size}, got {input_size_per_partition}."
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        fallback_weight_loader = extra_weight_attrs.pop("weight_loader", None)
+        weight_loader = (
+            layer.weight_loader_v2
+            if hasattr(layer, "weight_loader_v2")
+            else fallback_weight_loader
+        )
+        assert weight_loader is not None
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // 2,
+                dtype=torch.uint8,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        weight_scale = GroupQuantScaleParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+        weight_scale_2 = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale_2", weight_scale_2)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight_global_scale = Parameter(
+            layer.weight_scale_2.max().to(torch.float32),
+            requires_grad=False,
+        )
+        del layer.weight_scale_2
+        self.kernel.process_weights_after_loading(layer)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(layer=layer, x=x, bias=bias)

--- a/vllm_gguf_plugin/quantization/params.py
+++ b/vllm_gguf_plugin/quantization/params.py
@@ -7,6 +7,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+
 try:
     from vllm.model_executor.layers.fused_moe import RoutedExperts
 except ImportError:
@@ -42,8 +43,12 @@ def _resolve_gguf_weight_type_loader(
         return fallback_weight_loader
 
     def _gguf_weight_type_loader_v2(param, loaded_weight, loaded_shard_id=None):
-        if loaded_shard_id is None and hasattr(param, "_store"):
-            param._store(loaded_weight)
+        if hasattr(param, "_store"):
+            if isinstance(loaded_shard_id, tuple):
+                for shard_id in loaded_shard_id:
+                    param._store(loaded_weight, shard_id=shard_id)
+            else:
+                param._store(loaded_weight, shard_id=loaded_shard_id)
             return
         base_loader(param, loaded_weight, loaded_shard_id)
 

--- a/vllm_gguf_plugin/quantization/params.py
+++ b/vllm_gguf_plugin/quantization/params.py
@@ -7,7 +7,10 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.model_executor.layers.fused_moe import RoutedExperts
+try:
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+except ImportError:
+    from vllm.model_executor.layers.fused_moe import FusedMoE as RoutedExperts
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.parameter import BasevLLMParameter
 

--- a/vllm_gguf_plugin/quantization/vocal_embeds.py
+++ b/vllm_gguf_plugin/quantization/vocal_embeds.py
@@ -8,9 +8,9 @@ import torch
 from gguf import GGMLQuantizationType as WeightType
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.utils.torch_utils import direct_register_custom_op
 
 from .. import ops
+from .custom_ops import register_or_get_vllm_custom_op
 from .linear import GGUFLinearMethod
 from .params import (
     GGUFUninitializedWeightParameter,
@@ -56,15 +56,11 @@ def _apply_gguf_embedding_fake(
     return torch.empty(*x.shape, hidden_size, dtype=dtype, device=x.device)
 
 
-try:
-    direct_register_custom_op(
-        op_name="_apply_gguf_embedding",
-        op_func=_apply_gguf_embedding,
-        fake_impl=_apply_gguf_embedding_fake,
-    )
-    apply_gguf_embedding = torch.ops.vllm._apply_gguf_embedding
-except AttributeError as error:
-    raise error
+apply_gguf_embedding = register_or_get_vllm_custom_op(
+    op_name="_apply_gguf_embedding",
+    op_func=_apply_gguf_embedding,
+    fake_impl=_apply_gguf_embedding_fake,
+)
 
 
 class GGUFEmbeddingMethod(GGUFLinearMethod):

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import gguf
 import numpy as np
 import torch
-from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub import hf_hub_download, list_repo_files, snapshot_download
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -85,6 +85,57 @@ def _download_candidate_sort_key(path: str) -> tuple[bool, int, str, int, str]:
     return (True, normalized.count("-"), normalized, int(match.group(1)), path)
 
 
+def _mmproj_quant_tokens(quant_type: str) -> tuple[str, ...]:
+    quant_type = quant_type.upper()
+    tokens = [quant_type]
+    if "-" in quant_type:
+        tokens.append(quant_type.rsplit("-", 1)[1])
+    return tuple(dict.fromkeys(tokens))
+
+
+def _mmproj_candidate_sort_key(filename: str, quant_type: str) -> tuple[int, str]:
+    basename = Path(filename).name
+    name = basename.upper()
+    if basename.lower() == "mmproj.gguf":
+        priority = 0
+    elif any(token in name for token in _mmproj_quant_tokens(quant_type)):
+        priority = 1
+    elif "BF16" not in name and "F16" in name:
+        priority = 2
+    elif "BF16" in name:
+        priority = 3
+    elif "F32" in name:
+        priority = 4
+    else:
+        priority = 5
+    return priority, filename
+
+
+def _select_remote_mmproj_filename(
+    repo_id: str,
+    quant_type: str,
+    revision: str | None,
+) -> str | None:
+    try:
+        files = list_repo_files(repo_id, revision=revision)
+    except Exception as e:
+        logger.debug("Failed to inspect GGUF repo sidecars for %s: %s", repo_id, e)
+        return None
+
+    mmproj_files = [
+        filename
+        for filename in files
+        if filename.lower().endswith(".gguf")
+        and "mmproj" in Path(filename).name.lower()
+    ]
+    if not mmproj_files:
+        return None
+    return sorted(
+        mmproj_files,
+        key=lambda name: _mmproj_candidate_sort_key(name, quant_type),
+    )[0]
+
+
 def download_gguf(
     repo_id: str,
     quant_type: str,
@@ -104,6 +155,12 @@ def download_gguf(
             (pattern, f"*/{pattern}") for pattern in base_patterns
         )
     )
+    if mmproj_filename := _select_remote_mmproj_filename(
+        repo_id,
+        quant_type,
+        revision,
+    ):
+        allow_patterns.append(mmproj_filename)
 
     folder = snapshot_download(
         repo_id=repo_id,
@@ -116,6 +173,11 @@ def download_gguf(
     local_files: list[str] = []
     for pattern in allow_patterns:
         local_files.extend(glob.glob(os.path.join(folder, pattern)))
+    local_files = [
+        filename
+        for filename in local_files
+        if "mmproj" not in Path(filename).name.lower()
+    ]
 
     if not local_files:
         raise ValueError(

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -10,17 +10,34 @@ from pathlib import Path
 import gguf
 import numpy as np
 import torch
-from huggingface_hub import snapshot_download
+from huggingface_hub import hf_hub_download, snapshot_download
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
 
 _SPLIT_GGUF_RE = re.compile(r"-(\d+)-of-(\d+)\.gguf$")
+_HF_REPO_PART_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _split_gguf_match(path: str | Path) -> re.Match[str] | None:
     return _SPLIT_GGUF_RE.search(str(path))
+
+
+def expand_split_gguf_filenames(filename: str) -> list[str]:
+    match = _split_gguf_match(filename)
+    if match is None:
+        return [filename]
+
+    total = int(match.group(2))
+    shard_digits = len(match.group(1))
+    total_digits = len(match.group(2))
+    prefix = filename[: match.start(1)]
+    suffix = filename[match.end(2) :]
+    return [
+        f"{prefix}{idx:0{shard_digits}d}-of-{total:0{total_digits}d}{suffix}"
+        for idx in range(1, total + 1)
+    ]
 
 
 def resolve_gguf_file_set(model_path: str | Path) -> list[str]:
@@ -31,28 +48,33 @@ def resolve_gguf_file_set(model_path: str | Path) -> list[str]:
     that produces missing weights later in model load with much worse errors.
     """
     model_path = str(model_path)
-    match = _split_gguf_match(model_path)
-    if match is None:
-        return [model_path]
+    files = expand_split_gguf_filenames(model_path)
+    if len(files) == 1:
+        return files
 
-    total = int(match.group(2))
-    shard_digits = len(match.group(1))
-    total_digits = len(match.group(2))
-    prefix = model_path[: match.start(1)]
-    suffix = model_path[match.end(2) :]
-    files = [
-        f"{prefix}{idx:0{shard_digits}d}-of-{total:0{total_digits}d}{suffix}"
-        for idx in range(1, total + 1)
-    ]
     missing = [path for path in files if not os.path.isfile(path)]
     if missing:
         raise ValueError(
             "Incomplete split GGUF model: expected "
-            f"{total} shards for {model_path}, missing {len(missing)}: "
+            f"{len(files)} shards for {model_path}, missing {len(missing)}: "
             + ", ".join(missing)
         )
     logger.info("Resolved split GGUF model to %d shard files", len(files))
     return files
+
+
+def split_remote_gguf_file_ref(model_ref: str) -> tuple[str, str] | None:
+    """Split ``namespace/repo/path.gguf`` into HF repo ID and filename."""
+    parts = model_ref.split("/", 2)
+    if len(parts) != 3 or not parts[2].endswith(".gguf"):
+        return None
+    if not _HF_REPO_PART_RE.fullmatch(parts[0]):
+        return None
+    if not _HF_REPO_PART_RE.fullmatch(parts[1]):
+        return None
+    if any(segment in ("", ".", "..") for segment in parts[2].split("/")):
+        return None
+    return f"{parts[0]}/{parts[1]}", parts[2]
 
 
 def _download_candidate_sort_key(path: str) -> tuple[bool, int, str, int, str]:
@@ -104,6 +126,31 @@ def download_gguf(
     return resolve_gguf_file_set(local_files[0])[0]
 
 
+def download_gguf_file(
+    repo_id: str,
+    filename: str,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+) -> str:
+    """Download an exact GGUF file reference, including split shard sets."""
+    filenames = expand_split_gguf_filenames(filename)
+    if len(filenames) == 1:
+        return hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            cache_dir=cache_dir,
+            revision=revision,
+        )
+
+    folder = snapshot_download(
+        repo_id=repo_id,
+        cache_dir=cache_dir,
+        allow_patterns=filenames,
+        revision=revision,
+    )
+    return resolve_gguf_file_set(os.path.join(folder, filename))[0]
+
+
 def resolve_local_gguf(local_dir: str, quant_type: str) -> str:
     """Find a GGUF file matching *quant_type* in a local directory."""
     import glob as glob_mod
@@ -119,8 +166,8 @@ def resolve_local_gguf(local_dir: str, quant_type: str) -> str:
         raise ValueError(
             f"No GGUF file matching quant_type '{quant_type}' found in {local_dir}"
         )
-    matches.sort(key=lambda x: (x.count("-"), x))
-    return matches[0]
+    matches.sort(key=_download_candidate_sort_key)
+    return resolve_gguf_file_set(matches[0])[0]
 
 
 def get_gguf_extra_tensor_names(

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -3,6 +3,7 @@
 import glob
 import itertools
 import os
+import re
 from collections.abc import Generator
 from pathlib import Path
 
@@ -15,6 +16,53 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+_SPLIT_GGUF_RE = re.compile(r"-(\d+)-of-(\d+)\.gguf$")
+
+
+def _split_gguf_match(path: str | Path) -> re.Match[str] | None:
+    return _SPLIT_GGUF_RE.search(str(path))
+
+
+def resolve_gguf_file_set(model_path: str | Path) -> list[str]:
+    """Return the ordered GGUF files needed to load ``model_path``.
+
+    Split GGUF files use names such as ``model-00001-of-00003.gguf``.  vLLM's
+    loader should never silently continue with a partial split set, because
+    that produces missing weights later in model load with much worse errors.
+    """
+    model_path = str(model_path)
+    match = _split_gguf_match(model_path)
+    if match is None:
+        return [model_path]
+
+    total = int(match.group(2))
+    shard_digits = len(match.group(1))
+    total_digits = len(match.group(2))
+    prefix = model_path[: match.start(1)]
+    suffix = model_path[match.end(2) :]
+    files = [
+        f"{prefix}{idx:0{shard_digits}d}-of-{total:0{total_digits}d}{suffix}"
+        for idx in range(1, total + 1)
+    ]
+    missing = [path for path in files if not os.path.isfile(path)]
+    if missing:
+        raise ValueError(
+            "Incomplete split GGUF model: expected "
+            f"{total} shards for {model_path}, missing {len(missing)}: "
+            + ", ".join(missing)
+        )
+    logger.info("Resolved split GGUF model to %d shard files", len(files))
+    return files
+
+
+def _download_candidate_sort_key(path: str) -> tuple[bool, int, str, int, str]:
+    match = _split_gguf_match(path)
+    if match is None:
+        return (False, path.count("-"), path, 0, path)
+    normalized = _SPLIT_GGUF_RE.sub(".gguf", path)
+    return (True, normalized.count("-"), normalized, int(match.group(1)), path)
+
+
 def download_gguf(
     repo_id: str,
     quant_type: str,
@@ -24,11 +72,16 @@ def download_gguf(
 ) -> str:
     prefix_list = ["*.", "*-"]
     suffix_list = ["-*", ""]
-    allow_patterns = [
+    base_patterns = [
         f"{prefix}{qt}{suffix}.gguf"
         for qt in (quant_type.upper(), quant_type.lower())
         for prefix, suffix in itertools.product(prefix_list, suffix_list)
     ]
+    allow_patterns = list(
+        itertools.chain.from_iterable(
+            (pattern, f"*/{pattern}") for pattern in base_patterns
+        )
+    )
 
     folder = snapshot_download(
         repo_id=repo_id,
@@ -47,8 +100,8 @@ def download_gguf(
             f"Downloaded GGUF files not found in {folder} for quant_type {quant_type}"
         )
 
-    local_files.sort(key=lambda x: (x.count("-"), x))
-    return local_files[0]
+    local_files = sorted(set(local_files), key=_download_candidate_sort_key)
+    return resolve_gguf_file_set(local_files[0])[0]
 
 
 def resolve_local_gguf(local_dir: str, quant_type: str) -> str:

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -4,9 +4,13 @@
 from .base import BaseGGUFWeightsAdapter
 from .default import GGUFWeightsAdapter
 from .gemma3 import Gemma3GGUFAdapter
+from .gemma4 import Gemma4GGUFAdapter
+from .qwen3_5 import Qwen3_5GGUFAdapter
 
 _ADAPTER_REGISTRY: list[type[GGUFWeightsAdapter]] = [
     Gemma3GGUFAdapter,
+    Gemma4GGUFAdapter,
+    Qwen3_5GGUFAdapter,
 ]
 
 
@@ -22,5 +26,7 @@ __all__ = [
     "BaseGGUFWeightsAdapter",
     "GGUFWeightsAdapter",
     "Gemma3GGUFAdapter",
+    "Gemma4GGUFAdapter",
+    "Qwen3_5GGUFAdapter",
     "get_weights_adapter",
 ]

--- a/vllm_gguf_plugin/weights_adapter/base.py
+++ b/vllm_gguf_plugin/weights_adapter/base.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import torch
@@ -19,6 +19,7 @@ class GGUFLoadSpec:
     weights_source: list[str]
     unquantized_modules: list[str]
     gguf_to_hf_name_map: dict[str, str] | None = None
+    nvfp4_modules: list[str] = field(default_factory=list)
 
 
 class BaseGGUFWeightsAdapter(ABC):

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -14,6 +14,7 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 from vllm.logger import init_logger
 
 from ..gguf_utils import detect_gguf_multimodal, maybe_patch_hf_config_from_gguf
+from ..quantization.nvfp4 import iter_gguf_nvfp4_native_weights
 from ..weight_utils import (
     get_gguf_extra_tensor_names,
     get_gguf_weight_type_map,
@@ -31,6 +32,9 @@ logger = init_logger(__name__)
 _GGUF_MODEL_TYPE_ALIASES = {
     "gemma4": "gemma3",
 }
+
+_QWEIGHT_SUFFIX = ".qweight"
+_QWEIGHT_TYPE_SUFFIX = ".qweight_type"
 
 
 def _gguf_arch_model_type(model_type: str) -> str:
@@ -347,6 +351,10 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
 
     load_spec = None
 
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self._native_nvfp4_modules: set[str] = set()
+
     @classmethod
     def matches(cls, config) -> bool:
         del config
@@ -593,6 +601,23 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
         weights: Iterable[tuple[str, torch.Tensor]],
     ) -> Iterable[tuple[str, torch.Tensor]]:
         for hf_name, weight in weights:
+            if hf_name.endswith(_QWEIGHT_TYPE_SUFFIX):
+                module_name = hf_name.removesuffix(_QWEIGHT_TYPE_SUFFIX)
+                if module_name in self._native_nvfp4_modules:
+                    continue
+
+            if hf_name.endswith(_QWEIGHT_SUFFIX):
+                module_name = hf_name.removesuffix(_QWEIGHT_SUFFIX)
+                if module_name in self._native_nvfp4_modules:
+                    for native_name, native_weight in iter_gguf_nvfp4_native_weights(
+                        module_name, weight
+                    ):
+                        yield (
+                            native_name,
+                            self.transform_weight(native_name, native_weight),
+                        )
+                    continue
+
             yield hf_name, self.transform_weight(hf_name, weight)
 
     @staticmethod
@@ -652,6 +677,17 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
             if weight_type in ("F32", "F16", "BF16") and name.endswith(".weight")
         ]
 
+    @staticmethod
+    def get_native_nvfp4_modules(weight_type_map: dict[str, str]) -> list[str]:
+        return [
+            name.removesuffix(".weight")
+            for name, weight_type in weight_type_map.items()
+            if weight_type == "NVFP4"
+            and name.endswith(".weight")
+            and "embed_tokens" not in name
+            and "lm_head" not in name
+        ]
+
     def prepare_loading(
         self,
         model_path: str,
@@ -673,10 +709,12 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
             gguf_files, model_config.hf_config, gguf_to_hf_name_map
         )
         weight_type_map = self.get_weight_type_map(gguf_files, gguf_to_hf_name_map)
+        self._native_nvfp4_modules = set(self.get_native_nvfp4_modules(weight_type_map))
         self.load_spec = GGUFLoadSpec(
             weights_source=gguf_files,
             gguf_to_hf_name_map=gguf_to_hf_name_map,
             unquantized_modules=self.get_unquantized_modules(weight_type_map),
+            nvfp4_modules=sorted(self._native_nvfp4_modules),
         )
         return self.load_spec
 

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING
 import gguf
 import regex
 import torch
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 from vllm.logger import init_logger
 
-from ..gguf_utils import maybe_patch_hf_config_from_gguf
+from ..gguf_utils import detect_gguf_multimodal, maybe_patch_hf_config_from_gguf
 from ..weight_utils import (
     get_gguf_extra_tensor_names,
     get_gguf_weight_type_map,
@@ -27,6 +27,319 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
 logger = init_logger(__name__)
+
+_GGUF_MODEL_TYPE_ALIASES = {
+    "gemma4": "gemma3",
+}
+
+
+def _gguf_arch_model_type(model_type: str) -> str:
+    return _GGUF_MODEL_TYPE_ALIASES.get(model_type, model_type)
+
+
+def _gguf_name_with_suffix(base_name: str, suffix: str) -> str:
+    return f"{base_name}.{suffix}" if suffix else base_name
+
+
+def _get_vision_num_layers(config: PretrainedConfig) -> int:
+    vision_num_layers = getattr(config.vision_config, "num_hidden_layers", None)
+    if vision_num_layers is None:
+        vision_num_layers = config.vision_config.depth
+    return vision_num_layers
+
+
+def _is_multimodal_config(config: PretrainedConfig) -> bool:
+    return hasattr(config, "vision_config") and config.vision_config is not None
+
+
+def _uses_multimodal_weight_layout(
+    config: PretrainedConfig,
+    architectures: list[str] | None = None,
+) -> bool:
+    if not _is_multimodal_config(config):
+        return False
+
+    if architectures is None:
+        architectures = getattr(config, "architectures", None)
+    if not architectures:
+        return True
+
+    return any("ConditionalGeneration" in arch for arch in architectures)
+
+
+def _is_gemma4_mtp_config(config: PretrainedConfig) -> bool:
+    return config.model_type in ("gemma4_assistant", "gemma4_mtp")
+
+
+def _get_mtp_num_layers(text_config: PretrainedConfig) -> int:
+    return int(
+        getattr(
+            text_config,
+            "mtp_num_hidden_layers",
+            getattr(text_config, "num_nextn_predict_layers", 0),
+        )
+        or 0
+    )
+
+
+def _add_gemma4_mtp_gguf_mappings(
+    config: PretrainedConfig,
+    gguf_to_hf_name_map: dict[str, str],
+) -> None:
+    text_config = config.get_text_config()
+    num_layers = int(getattr(text_config, "num_hidden_layers", 0) or 0)
+
+    gguf_to_hf_name_map.update(
+        {
+            "token_embd.weight": "model.embed_tokens.weight",
+            "output_norm.weight": "model.norm.weight",
+            "nextn.pre_projection.weight": "model.pre_projection.weight",
+            "nextn.post_projection.weight": "model.post_projection.weight",
+        }
+    )
+
+    # Gemma4 MTP attention is Q-only and reuses the target model KV cache,
+    # so GGUF assistant blocks intentionally do not map attn_k/attn_v.
+    for idx in range(num_layers):
+        layer_prefix = f"model.layers.{idx}"
+        gguf_to_hf_name_map.update(
+            {
+                f"blk.{idx}.attn_norm.weight": (
+                    f"{layer_prefix}.input_layernorm.weight"
+                ),
+                f"blk.{idx}.attn_q.weight": f"{layer_prefix}.self_attn.q_proj.weight",
+                f"blk.{idx}.attn_output.weight": (
+                    f"{layer_prefix}.self_attn.o_proj.weight"
+                ),
+                f"blk.{idx}.attn_q_norm.weight": (
+                    f"{layer_prefix}.self_attn.q_norm.weight"
+                ),
+                f"blk.{idx}.post_attention_norm.weight": (
+                    f"{layer_prefix}.post_attention_layernorm.weight"
+                ),
+                f"blk.{idx}.ffn_norm.weight": (
+                    f"{layer_prefix}.pre_feedforward_layernorm.weight"
+                ),
+                f"blk.{idx}.post_ffw_norm.weight": (
+                    f"{layer_prefix}.post_feedforward_layernorm.weight"
+                ),
+                f"blk.{idx}.ffn_gate.weight": f"{layer_prefix}.mlp.gate_proj.weight",
+                f"blk.{idx}.ffn_up.weight": f"{layer_prefix}.mlp.up_proj.weight",
+                f"blk.{idx}.ffn_down.weight": f"{layer_prefix}.mlp.down_proj.weight",
+                f"blk.{idx}.layer_output_scale.weight": (
+                    f"{layer_prefix}.layer_scalar"
+                ),
+            }
+        )
+
+
+def _add_qwen3_5_mtp_gguf_mappings(
+    config: PretrainedConfig,
+    gguf_to_hf_name_map: dict[str, str],
+    sideload_params: list[re.Pattern],
+) -> None:
+    text_config = config.get_text_config()
+    num_mtp_layers = _get_mtp_num_layers(text_config)
+    if num_mtp_layers <= 0:
+        return
+
+    base_layer = int(getattr(text_config, "num_hidden_layers", 0) or 0)
+    shared_nextn_gguf_idx = base_layer
+    gguf_to_hf_name_map.update(
+        {
+            f"blk.{shared_nextn_gguf_idx}.nextn.eh_proj.weight": "mtp.fc.weight",
+            f"blk.{shared_nextn_gguf_idx}.nextn.enorm.weight": (
+                "mtp.pre_fc_norm_embedding.weight"
+            ),
+            f"blk.{shared_nextn_gguf_idx}.nextn.hnorm.weight": (
+                "mtp.pre_fc_norm_hidden.weight"
+            ),
+            f"blk.{shared_nextn_gguf_idx}.nextn.shared_head_norm.weight": (
+                "mtp.norm.weight"
+            ),
+            f"blk.{shared_nextn_gguf_idx}.nextn.embed_tokens.weight": (
+                "mtp.embed_tokens.weight"
+            ),
+        }
+    )
+    for mtp_idx in range(num_mtp_layers):
+        gguf_idx = base_layer + mtp_idx
+        layer_prefix = f"mtp.layers.{mtp_idx}"
+        gguf_to_hf_name_map.update(
+            {
+                f"blk.{gguf_idx}.attn_norm.weight": (
+                    f"{layer_prefix}.input_layernorm.weight"
+                ),
+                f"blk.{gguf_idx}.post_attention_norm.weight": (
+                    f"{layer_prefix}.post_attention_layernorm.weight"
+                ),
+                f"blk.{gguf_idx}.attn_q.weight": (
+                    f"{layer_prefix}.self_attn.q_proj.weight"
+                ),
+                f"blk.{gguf_idx}.attn_k.weight": (
+                    f"{layer_prefix}.self_attn.k_proj.weight"
+                ),
+                f"blk.{gguf_idx}.attn_v.weight": (
+                    f"{layer_prefix}.self_attn.v_proj.weight"
+                ),
+                f"blk.{gguf_idx}.attn_output.weight": (
+                    f"{layer_prefix}.self_attn.o_proj.weight"
+                ),
+                f"blk.{gguf_idx}.attn_q_norm.weight": (
+                    f"{layer_prefix}.self_attn.q_norm.weight"
+                ),
+                f"blk.{gguf_idx}.attn_k_norm.weight": (
+                    f"{layer_prefix}.self_attn.k_norm.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_gate.weight": (
+                    f"{layer_prefix}.mlp.gate_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_up.weight": f"{layer_prefix}.mlp.up_proj.weight",
+                f"blk.{gguf_idx}.ffn_down.weight": (
+                    f"{layer_prefix}.mlp.down_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_gate_inp.weight": (
+                    f"{layer_prefix}.mlp.gate.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_gate_inp_shexp.weight": (
+                    f"{layer_prefix}.mlp.shared_expert_gate.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_gate_shexp.weight": (
+                    f"{layer_prefix}.mlp.shared_expert.gate_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_up_shexp.weight": (
+                    f"{layer_prefix}.mlp.shared_expert.up_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_down_shexp.weight": (
+                    f"{layer_prefix}.mlp.shared_expert.down_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_gate_exps.weight": (
+                    f"{layer_prefix}.mlp.experts.0.gate_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_up_exps.weight": (
+                    f"{layer_prefix}.mlp.experts.0.up_proj.weight"
+                ),
+                f"blk.{gguf_idx}.ffn_down_exps.weight": (
+                    f"{layer_prefix}.mlp.experts.0.down_proj.weight"
+                ),
+            }
+        )
+        sideload_params.append(
+            regex.compile(
+                f"mtp\\.layers\\.{mtp_idx}"
+                r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
+            )
+        )
+
+
+def _add_gemma4_gguf_mappings(
+    config: PretrainedConfig,
+    gguf_to_hf_name_map: dict[str, str],
+    sideload_params: list[re.Pattern],
+) -> None:
+    text_config = config.get_text_config()
+    uses_multimodal_layout = _uses_multimodal_weight_layout(config)
+    layer_prefix_base = (
+        "model.language_model.layers" if uses_multimodal_layout else "model.layers"
+    )
+    for idx in range(text_config.num_hidden_layers):
+        layer_prefix = f"{layer_prefix_base}.{idx}"
+        gguf_to_hf_name_map[f"blk.{idx}.layer_output_scale.weight"] = (
+            f"{layer_prefix}.layer_scalar"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_inp.scale"] = (
+            f"{layer_prefix}.router.scale"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_inp.weight"] = (
+            f"{layer_prefix}.router.proj.weight"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.scale"] = (
+            f"{layer_prefix}.router.per_expert_scale"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_up_exps.weight"] = (
+            f"{layer_prefix}.experts.gate_up_proj.weight"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
+            f"{layer_prefix}.experts.down_proj.weight"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.post_ffw_norm_1.weight"] = (
+            f"{layer_prefix}.post_feedforward_layernorm_1.weight"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.post_ffw_norm_2.weight"] = (
+            f"{layer_prefix}.post_feedforward_layernorm_2.weight"
+        )
+        gguf_to_hf_name_map[f"blk.{idx}.pre_ffw_norm_2.weight"] = (
+            f"{layer_prefix}.pre_feedforward_layernorm_2.weight"
+        )
+        sideload_params.append(
+            regex.compile(
+                f"{re.escape(layer_prefix_base)}\\.{idx}"
+                r"\.experts\.(gate_up_proj|down_proj)(\.weight)?"
+            )
+        )
+
+    if uses_multimodal_layout:
+        gguf_to_hf_name_map.update(
+            {
+                "v.std_bias": "model.vision_tower.std_bias",
+                "v.std_scale": "model.vision_tower.std_scale",
+                "v.patch_embd.weight": (
+                    "model.vision_tower.patch_embedder.input_proj.weight"
+                ),
+                "v.position_embd.weight": (
+                    "model.vision_tower.patch_embedder.position_embedding_table"
+                ),
+                "mm.input_projection.weight": (
+                    "model.embed_vision.embedding_projection.weight"
+                ),
+            }
+        )
+
+        for idx in range(_get_vision_num_layers(config)):
+            vision_prefix = f"model.vision_tower.encoder.layers.{idx}"
+            gguf_to_hf_name_map.update(
+                {
+                    f"v.blk.{idx}.attn_q.weight": (
+                        f"{vision_prefix}.self_attn.q_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.attn_k.weight": (
+                        f"{vision_prefix}.self_attn.k_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.attn_v.weight": (
+                        f"{vision_prefix}.self_attn.v_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.attn_out.weight": (
+                        f"{vision_prefix}.self_attn.o_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.attn_q_norm.weight": (
+                        f"{vision_prefix}.self_attn.q_norm.weight"
+                    ),
+                    f"v.blk.{idx}.attn_k_norm.weight": (
+                        f"{vision_prefix}.self_attn.k_norm.weight"
+                    ),
+                    f"v.blk.{idx}.ffn_gate.weight": (
+                        f"{vision_prefix}.mlp.gate_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.ffn_up.weight": (
+                        f"{vision_prefix}.mlp.up_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.ffn_down.weight": (
+                        f"{vision_prefix}.mlp.down_proj.linear.weight"
+                    ),
+                    f"v.blk.{idx}.ln1.weight": (
+                        f"{vision_prefix}.input_layernorm.weight"
+                    ),
+                    f"v.blk.{idx}.attn_post_norm.weight": (
+                        f"{vision_prefix}.post_attention_layernorm.weight"
+                    ),
+                    f"v.blk.{idx}.ln2.weight": (
+                        f"{vision_prefix}.pre_feedforward_layernorm.weight"
+                    ),
+                    f"v.blk.{idx}.ffn_post_norm.weight": (
+                        f"{vision_prefix}.post_feedforward_layernorm.weight"
+                    ),
+                }
+            )
 
 
 class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
@@ -46,17 +359,22 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
         config = model_config.hf_config
         text_config = config.get_text_config()
         model_type = config.model_type
-        is_multimodal = (
-            hasattr(config, "vision_config") and config.vision_config is not None
-        )
+        is_multimodal = _uses_multimodal_weight_layout(config)
+        orig_model_type = model_type
 
         gguf_to_hf_name_map: dict[str, str] = {}
         sideload_params: list[re.Pattern] = []
+
+        if _is_gemma4_mtp_config(config):
+            _add_gemma4_mtp_gguf_mappings(config, gguf_to_hf_name_map)
+            return gguf_to_hf_name_map
 
         if model_type == "cohere":
             model_type = "command-r"
         if model_type == "gemma3_text":
             model_type = "gemma3"
+        if model_type == "gemma4":
+            _add_gemma4_gguf_mappings(config, gguf_to_hf_name_map, sideload_params)
         if model_type in ("deepseek_v3", "deepseek_v2"):
             model_type = "deepseek2"
             for idx in range(config.num_hidden_layers):
@@ -78,24 +396,60 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
                     )
                 )
-        if model_type in ("qwen2_moe", "qwen3_moe"):
+        if model_type == "qwen3_5":
+            model_type = "qwen35"
+        if model_type in ("qwen2_moe", "qwen3_moe", "qwen3_5_moe"):
             model_type = model_type.replace("_", "")
-            for idx in range(config.num_hidden_layers):
+            if is_multimodal and model_type == "qwen35moe":
+                layer_prefix = "model.language_model.layers"
+            else:
+                layer_prefix = "model.layers"
+            for idx in range(text_config.num_hidden_layers):
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
-                    f"model.layers.{idx}.mlp.experts.0.down_proj.weight"
+                    f"{layer_prefix}.{idx}.mlp.experts.0.down_proj.weight"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
-                    f"model.layers.{idx}.mlp.experts.0.gate_proj.weight"
+                    f"{layer_prefix}.{idx}.mlp.experts.0.gate_proj.weight"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
-                    f"model.layers.{idx}.mlp.experts.0.up_proj.weight"
+                    f"{layer_prefix}.{idx}.mlp.experts.0.up_proj.weight"
                 )
                 sideload_params.append(
                     regex.compile(
-                        f"model\\.layers\\.{idx}"
+                        f"{re.escape(layer_prefix)}\\.{idx}"
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
                     )
                 )
+        if orig_model_type in ("qwen3_5", "qwen3_5_moe"):
+            layer_prefix = (
+                "model.language_model.layers" if is_multimodal else "model.layers"
+            )
+            layer_types = getattr(text_config, "layer_types", [])
+            for idx, layer_type in enumerate(layer_types):
+                if layer_type == "linear_attention":
+                    gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.bias"] = (
+                        f"{layer_prefix}.{idx}.linear_attn.dt_bias"
+                    )
+            _add_qwen3_5_mtp_gguf_mappings(config, gguf_to_hf_name_map, sideload_params)
+        if orig_model_type in ("qwen3_5", "qwen3_5_moe") and is_multimodal:
+            gguf_to_hf_name_map.update(
+                {
+                    "token_embd.weight": "model.language_model.embed_tokens.weight",
+                    "v.patch_embd.weight.1": "model.visual.patch_embed.proj.weight.1",
+                    "v.post_ln.weight": "model.visual.merger.norm.weight",
+                    "v.post_ln.bias": "model.visual.merger.norm.bias",
+                    "mm.0.weight": "model.visual.merger.linear_fc1.weight",
+                    "mm.0.bias": "model.visual.merger.linear_fc1.bias",
+                    "mm.2.weight": "model.visual.merger.linear_fc2.weight",
+                    "mm.2.bias": "model.visual.merger.linear_fc2.bias",
+                }
+            )
+            sideload_params.extend(
+                [
+                    regex.compile(r"model\.visual\.merger\.norm\.weight"),
+                    regex.compile(r"model\.visual\.merger\.norm\.bias"),
+                ]
+            )
         if model_type == "olmoe":
             for idx in range(config.num_hidden_layers):
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
@@ -143,7 +497,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
 
         arch = None
         for key, value in gguf.MODEL_ARCH_NAMES.items():
-            if value == model_type:
+            if value == _gguf_arch_model_type(model_type):
                 arch = key
                 break
         if arch is None:
@@ -154,14 +508,18 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
         if is_multimodal:
             mm_proj_arch = gguf.MODEL_ARCH.MMPROJ
             vision_name_map = gguf.get_tensor_name_map(
-                mm_proj_arch, config.vision_config.num_hidden_layers
+                mm_proj_arch, _get_vision_num_layers(config)
             )
         else:
             vision_name_map = None
 
         with torch.device("meta"):
-            dummy_model = AutoModelForCausalLM.from_config(
-                config, trust_remote_code=model_config.trust_remote_code
+            auto_cls = (
+                AutoModelForImageTextToText if is_multimodal else AutoModelForCausalLM
+            )
+            auto_config = config if is_multimodal else text_config
+            dummy_model = auto_cls.from_config(
+                auto_config, trust_remote_code=model_config.trust_remote_code
             )
 
         state_dict = dummy_model.state_dict()
@@ -206,7 +564,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 gguf_name = text_name_map.get_name(base_name)
             if gguf_name is None:
                 return None
-            return gguf_name + "." + suffix
+            return _gguf_name_with_suffix(gguf_name, suffix)
 
         unmapped_params = []
         for hf_name in state_dict:
@@ -241,9 +599,26 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
     def _get_all_gguf_files(model_path: str) -> list[str]:
         return resolve_gguf_file_set(model_path)
 
-    def update_tie_word_embeddings(
+    def _get_weight_sources(
         self,
         model_path: str,
+        hf_config: PretrainedConfig,
+        use_multimodal_weight_layout: bool | None = None,
+    ) -> list[str]:
+        gguf_files = self._get_all_gguf_files(model_path)
+        if use_multimodal_weight_layout is None:
+            use_multimodal_weight_layout = _uses_multimodal_weight_layout(hf_config)
+        if use_multimodal_weight_layout:
+            mm_proj_path = detect_gguf_multimodal(model_path)
+            if mm_proj_path is not None:
+                mm_proj_file = str(mm_proj_path)
+                if mm_proj_file not in gguf_files:
+                    gguf_files.append(mm_proj_file)
+        return gguf_files
+
+    def update_tie_word_embeddings(
+        self,
+        gguf_files: list[str],
         hf_config: PretrainedConfig,
         gguf_to_hf_name_map: dict[str, str],
     ) -> None:
@@ -251,7 +626,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
             return
 
         all_extra_names = []
-        for gguf_file in self._get_all_gguf_files(model_path):
+        for gguf_file in gguf_files:
             all_extra_names.extend(
                 get_gguf_extra_tensor_names(gguf_file, gguf_to_hf_name_map)
             )
@@ -259,11 +634,11 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
 
     def get_weight_type_map(
         self,
-        model_path: str,
+        gguf_files: list[str],
         gguf_to_hf_name_map: dict[str, str],
     ) -> dict[str, str]:
         weight_type_map = {}
-        for gguf_file in self._get_all_gguf_files(model_path):
+        for gguf_file in gguf_files:
             weight_type_map.update(
                 get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
             )
@@ -286,12 +661,20 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
             model_path, model_config.hf_config
         )
         gguf_to_hf_name_map = self.build_name_map(model_config)
-        self.update_tie_word_embeddings(
-            model_path, model_config.hf_config, gguf_to_hf_name_map
+        use_multimodal_weight_layout = _uses_multimodal_weight_layout(
+            model_config.hf_config
         )
-        weight_type_map = self.get_weight_type_map(model_path, gguf_to_hf_name_map)
+        gguf_files = self._get_weight_sources(
+            model_path,
+            model_config.hf_config,
+            use_multimodal_weight_layout,
+        )
+        self.update_tie_word_embeddings(
+            gguf_files, model_config.hf_config, gguf_to_hf_name_map
+        )
+        weight_type_map = self.get_weight_type_map(gguf_files, gguf_to_hf_name_map)
         self.load_spec = GGUFLoadSpec(
-            weights_source=self._get_all_gguf_files(model_path),
+            weights_source=gguf_files,
             gguf_to_hf_name_map=gguf_to_hf_name_map,
             unquantized_modules=self.get_unquantized_modules(weight_type_map),
         )

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
@@ -19,6 +18,7 @@ from ..weight_utils import (
     get_gguf_extra_tensor_names,
     get_gguf_weight_type_map,
     gguf_quant_weights_iterator_multi,
+    resolve_gguf_file_set,
 )
 from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
 
@@ -239,21 +239,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
 
     @staticmethod
     def _get_all_gguf_files(model_path: str) -> list[str]:
-        match = re.search(r"-(\d+)-of-(\d+)\.gguf$", model_path)
-        if not match:
-            return [model_path]
-        total = int(match.group(2))
-        num_digits = len(match.group(1))
-        prefix = model_path[: match.start(1)]
-        suffix = model_path[match.end(2) :]
-        files = []
-        for i in range(1, total + 1):
-            shard_path = f"{prefix}{i:0{num_digits}d}-of-{total:0{num_digits}d}{suffix}"
-            if os.path.isfile(shard_path):
-                files.append(shard_path)
-        if files:
-            logger.info("Discovered %d GGUF shard files", len(files))
-        return files if files else [model_path]
+        return resolve_gguf_file_set(model_path)
 
     def update_tie_word_embeddings(
         self,

--- a/vllm_gguf_plugin/weights_adapter/gemma3.py
+++ b/vllm_gguf_plugin/weights_adapter/gemma3.py
@@ -13,6 +13,7 @@ from ..gguf_utils import detect_gguf_multimodal, maybe_patch_hf_config_from_gguf
 from ..weight_utils import (
     get_gguf_unquantized_params,
     gguf_quant_weights_iterator_multi,
+    resolve_gguf_file_set,
 )
 from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
 
@@ -96,10 +97,10 @@ class Gemma3GGUFAdapter(BaseGGUFWeightsAdapter):
         model_config.hf_config = self.patch_hf_config(
             model_path, model_config.hf_config
         )
-        gguf_files = [model_path]
+        gguf_files = resolve_gguf_file_set(model_path)
         mm_proj_path = detect_gguf_multimodal(model_path)
         if mm_proj_path:
-            gguf_files.append(mm_proj_path)
+            gguf_files.extend(resolve_gguf_file_set(mm_proj_path))
         self.mapper = build_gemma3_mapper(is_multimodal=mm_proj_path is not None)
         unquantized_params = get_gguf_unquantized_params(gguf_files)
         unquantized_modules = list(

--- a/vllm_gguf_plugin/weights_adapter/gemma4.py
+++ b/vllm_gguf_plugin/weights_adapter/gemma4.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import torch
+
+from .default import GGUFWeightsAdapter
+
+
+def _flatten_gemma4_patch_embed_weight(weight: torch.Tensor) -> torch.Tensor:
+    return weight.flatten(1) if weight.dim() == 4 else weight
+
+
+def _transform_gemma4_weight_name(name: str) -> str:
+    replacements = {
+        ".experts.gate_up_proj.qweight_type": (
+            ".moe.experts.routed_experts.w13_qweight_type"
+        ),
+        ".experts.gate_up_proj.qweight": (".moe.experts.routed_experts.w13_qweight"),
+        ".experts.down_proj.qweight_type": (
+            ".moe.experts.routed_experts.w2_qweight_type"
+        ),
+        ".experts.down_proj.qweight": ".moe.experts.routed_experts.w2_qweight",
+    }
+    for old, new in replacements.items():
+        if name.endswith(old):
+            return name.removesuffix(old) + new
+    return name
+
+
+class Gemma4GGUFAdapter(GGUFWeightsAdapter):
+    """Adapter for Gemma4 GGUF models."""
+
+    @classmethod
+    def matches(cls, config) -> bool:
+        return config.model_type in ("gemma4", "gemma4_assistant", "gemma4_mtp")
+
+    def map_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        for name, weight in weights:
+            name = _transform_gemma4_weight_name(name)
+            yield name, self.transform_weight(name, weight)
+
+    def transform_weight(
+        self,
+        hf_name: str,
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        if hf_name == "model.vision_tower.patch_embedder.input_proj.weight":
+            return _flatten_gemma4_patch_embed_weight(weight)
+        return weight

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+import gguf
+import torch
+
+from .default import GGUFWeightsAdapter
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+
+_QWEN3_5_PATCH_EMBED_WEIGHT = "model.visual.patch_embed.proj.weight"
+_QWEN3_5_PATCH_EMBED_WEIGHT_1 = f"{_QWEN3_5_PATCH_EMBED_WEIGHT}.1"
+_QWEIGHT_SUFFIX = ".qweight"
+_QWEIGHT_TYPE_SUFFIX = ".qweight_type"
+
+
+def _get_text_config(config):
+    if hasattr(config, "get_text_config"):
+        return config.get_text_config()
+    text_config = getattr(config, "text_config", None)
+    return text_config if text_config is not None else config
+
+
+def _qwen3_5_linear_attention_dims(config) -> tuple[int, int, int, int] | None:
+    text_config = _get_text_config(config)
+    num_k_heads = getattr(text_config, "linear_num_key_heads", None)
+    num_v_heads = getattr(text_config, "linear_num_value_heads", None)
+    head_k_dim = getattr(text_config, "linear_key_head_dim", None)
+    head_v_dim = getattr(text_config, "linear_value_head_dim", None)
+    if None in (num_k_heads, num_v_heads, head_k_dim, head_v_dim):
+        return None
+
+    num_k_heads = int(num_k_heads)
+    num_v_heads = int(num_v_heads)
+    head_k_dim = int(head_k_dim)
+    head_v_dim = int(head_v_dim)
+    if num_k_heads <= 0 or num_v_heads <= 0:
+        return None
+    if num_k_heads == num_v_heads:
+        return None
+    if num_v_heads % num_k_heads != 0:
+        return None
+    return num_k_heads, num_v_heads, head_k_dim, head_v_dim
+
+
+def _tiled_to_grouped_v_heads(
+    tensor: torch.Tensor,
+    dim: int,
+    num_k_heads: int,
+    num_v_per_k: int,
+    head_dim: int,
+) -> torch.Tensor:
+    shape = list(tensor.shape)
+    if dim < 0:
+        dim += len(shape)
+    if shape[dim] != num_k_heads * num_v_per_k * head_dim:
+        return tensor
+
+    new_shape = shape[:dim] + [num_v_per_k, num_k_heads, head_dim] + shape[dim + 1 :]
+    tensor = tensor.reshape(*new_shape)
+    perm = list(range(len(new_shape)))
+    perm[dim], perm[dim + 1] = perm[dim + 1], perm[dim]
+    return tensor.permute(*perm).contiguous().reshape(*shape)
+
+
+def _maybe_restore_qwen3_5_gdn_layout(
+    name: str,
+    weight: torch.Tensor,
+    config,
+) -> torch.Tensor:
+    if ".linear_attn." not in name:
+        return weight
+
+    dims = _qwen3_5_linear_attention_dims(config)
+    if dims is None:
+        return weight
+    num_k_heads, num_v_heads, head_k_dim, head_v_dim = dims
+    num_v_per_k = num_v_heads // num_k_heads
+    key_dim = num_k_heads * head_k_dim
+    value_dim = num_v_heads * head_v_dim
+
+    if ".linear_attn.in_proj_qkv" in name:
+        if weight.shape[0] != 2 * key_dim + value_dim:
+            return weight
+        q = weight[:key_dim]
+        k = weight[key_dim : 2 * key_dim]
+        v = weight[2 * key_dim :]
+        v = _tiled_to_grouped_v_heads(v, 0, num_k_heads, num_v_per_k, head_v_dim)
+        return torch.cat((q, k, v), dim=0)
+
+    if ".linear_attn.in_proj_z" in name:
+        return _tiled_to_grouped_v_heads(
+            weight, 0, num_k_heads, num_v_per_k, head_v_dim
+        )
+
+    if ".linear_attn.in_proj_a" in name or ".linear_attn.in_proj_b" in name:
+        return _tiled_to_grouped_v_heads(weight, 0, num_k_heads, num_v_per_k, 1)
+
+    if name.endswith(".linear_attn.dt_bias") or ".linear_attn.dt_proj" in name:
+        if weight.dim() == 1:
+            return _tiled_to_grouped_v_heads(
+                weight.unsqueeze(-1), 0, num_k_heads, num_v_per_k, 1
+            ).squeeze(-1)
+        return _tiled_to_grouped_v_heads(weight, -1, num_k_heads, num_v_per_k, 1)
+
+    if name.endswith(".linear_attn.A_log"):
+        if torch.any(weight >= 0):
+            raise ValueError(
+                "Qwen3.5 GGUF A_log tensor is expected to store negative "
+                "-exp(A_log) values"
+            )
+        restored = torch.log(-weight.to(torch.float32))
+        if restored.dim() == 1:
+            return _tiled_to_grouped_v_heads(
+                restored.unsqueeze(-1), 0, num_k_heads, num_v_per_k, 1
+            ).squeeze(-1)
+        return _tiled_to_grouped_v_heads(restored, -1, num_k_heads, num_v_per_k, 1)
+
+    if ".linear_attn.conv1d" in name:
+        conv_weight = weight.squeeze(1) if weight.dim() == 3 else weight
+        if conv_weight.shape[0] != 2 * key_dim + value_dim:
+            return conv_weight[:, None, :] if conv_weight.dim() == 2 else conv_weight
+        qk_part = conv_weight[: 2 * key_dim]
+        v_part = conv_weight[2 * key_dim :]
+        v_part = _tiled_to_grouped_v_heads(
+            v_part, 0, num_k_heads, num_v_per_k, head_v_dim
+        )
+        return torch.cat((qk_part, v_part), dim=0)[:, None, :]
+
+    if ".linear_attn.out_proj" in name:
+        return _tiled_to_grouped_v_heads(
+            weight, 1, num_k_heads, num_v_per_k, head_v_dim
+        )
+
+    return weight
+
+
+def _maybe_reshape_qwen3_5_gguf_weight(
+    name: str,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    if "mlp.shared_expert_gate" in name and weight.dim() == 1:
+        return weight[None, :]
+    if "linear_attn.conv1d.weight" in name and weight.dim() == 2:
+        return weight[:, None, :]
+    return weight
+
+
+def _maybe_restore_qwen3_5_norm_weight(
+    name: str,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    if not name.endswith("norm.weight") or name.endswith("linear_attn.norm.weight"):
+        return weight
+    text_norm_prefixes = (
+        "model.layers.",
+        "model.language_model.layers.",
+    )
+    text_norm_names = (
+        "model.norm.weight",
+        "model.language_model.norm.weight",
+    )
+    if name in text_norm_names or name.startswith(text_norm_prefixes):
+        # llama.cpp stores Qwen3.5 text RMSNorm weights as weight + 1.
+        return weight - 1
+    return weight
+
+
+def _dequantize_gguf_weight(
+    weight: torch.Tensor,
+    qweight_type: gguf.GGMLQuantizationType,
+) -> torch.Tensor:
+    dense = gguf.quants.dequantize(weight.detach().cpu().numpy(), qweight_type)
+    return torch.from_numpy(dense.copy())
+
+
+class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
+    """Adapter for Qwen3.5 GGUF models."""
+
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self._forced_dequantized_modules: set[str] = set()
+        self._qweight_types: dict[str, gguf.GGMLQuantizationType] = {}
+
+    @classmethod
+    def matches(cls, config) -> bool:
+        return config.model_type in ("qwen3_5", "qwen3_5_moe", "qwen3_5_mtp")
+
+    def prepare_loading(
+        self,
+        model_path: str,
+        model_config: ModelConfig,
+    ):
+        load_spec = super().prepare_loading(model_path, model_config)
+        self._forced_dequantized_modules.clear()
+        if _qwen3_5_linear_attention_dims(self.config) is None:
+            return load_spec
+        if load_spec.gguf_to_hf_name_map is None:
+            return load_spec
+
+        for hf_name in load_spec.gguf_to_hf_name_map.values():
+            if hf_name.endswith(".linear_attn.out_proj.weight"):
+                module_name = hf_name.removesuffix(".weight")
+                self._forced_dequantized_modules.add(module_name)
+                if module_name not in load_spec.unquantized_modules:
+                    load_spec.unquantized_modules.append(module_name)
+        return load_spec
+
+    def map_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        self._qweight_types.clear()
+        patch_weight: torch.Tensor | None = None
+        patch_weight_1: torch.Tensor | None = None
+
+        for hf_name, weight in weights:
+            if hf_name.endswith(_QWEIGHT_TYPE_SUFFIX):
+                module_name = hf_name.removesuffix(_QWEIGHT_TYPE_SUFFIX)
+                qweight_type = gguf.GGMLQuantizationType(int(weight.item()))
+                self._qweight_types[module_name] = qweight_type
+                if module_name in self._forced_dequantized_modules:
+                    continue
+                yield hf_name, weight
+                continue
+
+            if hf_name.endswith(_QWEIGHT_SUFFIX):
+                module_name = hf_name.removesuffix(_QWEIGHT_SUFFIX)
+                if module_name in self._forced_dequantized_modules:
+                    qweight_type = self._qweight_types.get(module_name)
+                    if qweight_type is None:
+                        raise ValueError(
+                            "Missing GGUF qweight_type for forced dense tensor "
+                            f"{hf_name}"
+                        )
+                    hf_name = f"{module_name}.weight"
+                    weight = _dequantize_gguf_weight(weight, qweight_type)
+
+            if hf_name == _QWEN3_5_PATCH_EMBED_WEIGHT:
+                patch_weight = weight
+                continue
+            if hf_name == _QWEN3_5_PATCH_EMBED_WEIGHT_1:
+                patch_weight_1 = weight
+                continue
+            yield hf_name, self.transform_weight(hf_name, weight)
+
+        if patch_weight is None:
+            if patch_weight_1 is not None:
+                yield _QWEN3_5_PATCH_EMBED_WEIGHT_1, patch_weight_1
+            return
+
+        if patch_weight_1 is not None:
+            patch_weight = torch.stack((patch_weight, patch_weight_1), dim=2)
+        yield (
+            _QWEN3_5_PATCH_EMBED_WEIGHT,
+            self.transform_weight(_QWEN3_5_PATCH_EMBED_WEIGHT, patch_weight),
+        )
+
+    def transform_weight(
+        self,
+        hf_name: str,
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        weight = _maybe_restore_qwen3_5_gdn_layout(hf_name, weight, self.config)
+        weight = _maybe_restore_qwen3_5_norm_weight(hf_name, weight)
+        return _maybe_reshape_qwen3_5_gguf_weight(hf_name, weight)

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 _QWEN3_5_PATCH_EMBED_WEIGHT = "model.visual.patch_embed.proj.weight"
 _QWEN3_5_PATCH_EMBED_WEIGHT_1 = f"{_QWEN3_5_PATCH_EMBED_WEIGHT}.1"
+_QWEN3_5_TOKEN_EMBD_WEIGHT = "token_embd.weight"
 _QWEIGHT_SUFFIX = ".qweight"
 _QWEIGHT_TYPE_SUFFIX = ".qweight_type"
 
@@ -180,6 +181,53 @@ def _dequantize_gguf_weight(
     return torch.from_numpy(dense.copy())
 
 
+def _force_dequantized_gguf_weight(
+    load_spec,
+    forced_dequantized_modules: set[str],
+    gguf_name: str,
+) -> None:
+    if load_spec.gguf_to_hf_name_map is None:
+        return
+    hf_name = load_spec.gguf_to_hf_name_map.get(gguf_name)
+    if hf_name is None or not hf_name.endswith(".weight"):
+        return
+
+    module_name = hf_name.removesuffix(".weight")
+    forced_dequantized_modules.add(module_name)
+    if module_name not in load_spec.unquantized_modules:
+        load_spec.unquantized_modules.append(module_name)
+
+
+def _qwen3_5_embed_tokens_uses_quant_config() -> bool:
+    import inspect
+
+    try:
+        from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+    except ImportError:
+        return False
+
+    init = Qwen3_5Model.__init__
+    init_candidates = [init, inspect.unwrap(init)]
+    for cell in getattr(init, "__closure__", ()) or ():
+        try:
+            cell_value = cell.cell_contents
+        except ValueError:
+            continue
+        if inspect.isfunction(cell_value):
+            init_candidates.append(inspect.unwrap(cell_value))
+
+    for init_candidate in init_candidates:
+        init_code = getattr(init_candidate, "__code__", None)
+        if init_code is None:
+            continue
+        if "VocabParallelEmbedding" in init_code.co_names and (
+            "quant_config" in init_code.co_names
+            or "quant_config" in init_code.co_varnames
+        ):
+            return True
+    return False
+
+
 class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
     """Adapter for Qwen3.5 GGUF models."""
 
@@ -199,6 +247,15 @@ class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
     ):
         load_spec = super().prepare_loading(model_path, model_config)
         self._forced_dequantized_modules.clear()
+        # Older vLLM builds construct Qwen3.5 embed_tokens without quant_config,
+        # so they need a dense compatibility fallback. Newer builds can keep
+        # the GGUF token embedding packed and run it through GGUFEmbeddingMethod.
+        if not _qwen3_5_embed_tokens_uses_quant_config():
+            _force_dequantized_gguf_weight(
+                load_spec,
+                self._forced_dequantized_modules,
+                _QWEN3_5_TOKEN_EMBD_WEIGHT,
+            )
         if _qwen3_5_linear_attention_dims(self.config) is None:
             return load_spec
         if load_spec.gguf_to_hf_name_map is None:

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import gguf
 import torch
 
+from ..quantization.nvfp4 import iter_gguf_nvfp4_native_weights
 from .default import GGUFWeightsAdapter
 
 if TYPE_CHECKING:
@@ -184,6 +185,7 @@ def _dequantize_gguf_weight(
 def _force_dequantized_gguf_weight(
     load_spec,
     forced_dequantized_modules: set[str],
+    native_nvfp4_modules: set[str],
     gguf_name: str,
 ) -> None:
     if load_spec.gguf_to_hf_name_map is None:
@@ -194,6 +196,9 @@ def _force_dequantized_gguf_weight(
 
     module_name = hf_name.removesuffix(".weight")
     forced_dequantized_modules.add(module_name)
+    native_nvfp4_modules.discard(module_name)
+    if hasattr(load_spec, "nvfp4_modules") and module_name in load_spec.nvfp4_modules:
+        load_spec.nvfp4_modules.remove(module_name)
     if module_name not in load_spec.unquantized_modules:
         load_spec.unquantized_modules.append(module_name)
 
@@ -254,6 +259,7 @@ class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
             _force_dequantized_gguf_weight(
                 load_spec,
                 self._forced_dequantized_modules,
+                self._native_nvfp4_modules,
                 _QWEN3_5_TOKEN_EMBD_WEIGHT,
             )
         if _qwen3_5_linear_attention_dims(self.config) is None:
@@ -265,6 +271,12 @@ class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
             if hf_name.endswith(".linear_attn.out_proj.weight"):
                 module_name = hf_name.removesuffix(".weight")
                 self._forced_dequantized_modules.add(module_name)
+                self._native_nvfp4_modules.discard(module_name)
+                if (
+                    hasattr(load_spec, "nvfp4_modules")
+                    and module_name in load_spec.nvfp4_modules
+                ):
+                    load_spec.nvfp4_modules.remove(module_name)
                 if module_name not in load_spec.unquantized_modules:
                     load_spec.unquantized_modules.append(module_name)
         return load_spec
@@ -282,7 +294,10 @@ class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
                 module_name = hf_name.removesuffix(_QWEIGHT_TYPE_SUFFIX)
                 qweight_type = gguf.GGMLQuantizationType(int(weight.item()))
                 self._qweight_types[module_name] = qweight_type
-                if module_name in self._forced_dequantized_modules:
+                if (
+                    module_name in self._forced_dequantized_modules
+                    or module_name in self._native_nvfp4_modules
+                ):
                     continue
                 yield hf_name, weight
                 continue
@@ -298,6 +313,15 @@ class Qwen3_5GGUFAdapter(GGUFWeightsAdapter):
                         )
                     hf_name = f"{module_name}.weight"
                     weight = _dequantize_gguf_weight(weight, qweight_type)
+                elif module_name in self._native_nvfp4_modules:
+                    for native_name, native_weight in iter_gguf_nvfp4_native_weights(
+                        module_name, weight
+                    ):
+                        yield (
+                            native_name,
+                            self.transform_weight(native_name, native_weight),
+                        )
+                    continue
 
             if hf_name == _QWEN3_5_PATCH_EMBED_WEIGHT:
                 patch_weight = weight


### PR DESCRIPTION
Stacked after #37. Until #37 lands, review the top commit only: 63522ee.

WHAT changed
- Detect GGUF `NVFP4` linear tensors during adapter preparation and route those modules to a new native NVFP4 linear method.
- Rewrite GGUF `qweight` payloads into vLLM-native `weight`, `weight_scale`, and `weight_scale_2` tensors.
- Convert the GGUF layout correctly: repack NVFP4 nibbles into vLLM E2M1 order and convert UE4M3 scale bytes to torch FP8 E4M3FN.

WHY
- vLLM already has NVFP4 kernels, but GGUF `NVFP4` arrives as a GGUF block tensor plus type tag, so the plugin previously could not use those kernels.
- This keeps weights packed and runs through vLLM native NVFP4 W4A16/Marlin instead of dequantizing to dense weights.

HOW
- Extend `GGUFLoadSpec`/`GGUFConfig` with `nvfp4_modules` so quant-method selection happens before model initialization.
- Add `GGUFNvFp4LinearMethod`, backed by `init_nvfp4_linear_kernel(use_a16=True)`, with vLLM native parameter classes.
- Keep Qwen3.5 forced dense compatibility fallbacks higher priority than native NVFP4 routing.

Validation
- `uvx ruff check ...`
- `uvx ruff format --check ...`
- `python3 -m compileall ...`
- Spark sp1: `pytest -q tests/test_plugin.py` -> 50 passed
- Spark sp1: GGUF NVFP4 split dequant matches gguf-py exactly (`max 0.0 mean 0.0`)
- Spark sp1: synthetic 128x128 NVFP4 Marlin smoke matched dense reference (`max_err 0.0 mean_err 0.0`)
- Spark sp1: Qwen3.5 Q4_K_M GGUF smoke generated successfully