### PR TITLE
fix: remove Blackwell bf16 restriction 

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -64,6 +64,15 @@ def test_oot_config_reuses_in_tree_behavior():
     assert repr(quant_config) == "GGUFConfig()"
 
 
+def test_supported_act_dtypes_includes_bfloat16():
+    quant_config = OOTGGUFConfig.from_config({})
+    supported = quant_config.get_supported_act_dtypes()
+
+    assert torch.half in supported
+    assert torch.bfloat16 in supported
+    assert torch.float32 in supported
+
+
 def test_gguf_linear_uses_weight_loader_v2(monkeypatch):
     register()
     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)

--- a/vllm_gguf_plugin/quantization/config.py
+++ b/vllm_gguf_plugin/quantization/config.py
@@ -20,7 +20,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.models.utils import WeightsMapper
 
-from .utils import is_layer_skipped_gguf, logger
+from .utils import is_layer_skipped_gguf
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization import QuantizationMethods

--- a/vllm_gguf_plugin/quantization/config.py
+++ b/vllm_gguf_plugin/quantization/config.py
@@ -19,7 +19,6 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.model_executor.models.utils import WeightsMapper
-from vllm.platforms import current_platform
 
 from .utils import is_layer_skipped_gguf, logger
 
@@ -41,11 +40,6 @@ class GGUFConfig(QuantizationConfig):
         return "gguf"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
-        # GGUF dequantization kernels use half precision (fp16) internally.
-        # bfloat16 has precision issues on Blackwell devices.
-        if current_platform.has_device_capability(100):
-            logger.warning_once("GGUF has precision issues with bfloat16 on Blackwell.")
-            return [torch.half, torch.float32]
         return [torch.half, torch.bfloat16, torch.float32]
 
     @classmethod


### PR DESCRIPTION
## Summary

Remove the `has_device_capability(100)` check that blocks bfloat16 on Blackwell devices. Both the Triton and CUDA backends correctly handle bf16 output.

Follows up from https://github.com/vllm-project/vllm/pull/47470 where @Isotr0py suggested verifying and removing this limitation.

## Analysis

The restriction was added in 87b598de (2026-05-10), before the Triton dequantize backend existed. The Triton backend was added in a4940696 (2026-06-11) with explicit bf16 support.

**Triton backend:**
- `TRITON_DEQUANT_SUPPORTED_DTYPES` includes `torch.bfloat16` ([utils.py#L15-L19](https://github.com/vllm-project/vllm-gguf-plugin/blob/a494069684fcbfb8c23aff8266d9bceea7569b57/vllm_gguf_plugin/triton/dequantize/utils.py#L15-L19))
- Kernels compute in float32, `tl.store` auto-casts to output tensor dtype
- `torch>=2.9` bundles Triton 3.3+ which supports sm_100
- bf16 is already tested in CI: `DTYPES = [torch.half, torch.bfloat16, torch.float32]` ([test_kernels.py#L20](https://github.com/vllm-project/vllm-gguf-plugin/blob/5ea40f258ddd39aa722d0fdf95eee57d3efc2f8a/tests/test_kernels.py#L20))

**CUDA backend:**
- No affected path

## Changes

- `vllm_gguf_plugin/quantization/config.py`: removed the capability check and unused `current_platform` import

cc @Isotr0py

Signed-off-by: Isaac Hernandez <isadohergar@gmail.com>