### PR TITLE
Preserve GGUF model path in engine args

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -230,8 +230,10 @@ def test_register_sets_engine_args_for_gguf_model(monkeypatch):
     engine_args.create_model_config()
 
     assert captured["config_format"] == "gguf"
-    assert captured["model"] == "/tmp/tokenizer"
+    assert captured["model"] == "/tmp/model.gguf"
+    assert captured["hf_config_path"] == "/tmp/tokenizer"
     assert captured["model_weights"] == "/tmp/model.gguf"
+    assert captured["tokenizer"] == "/tmp/tokenizer"
     assert captured["quantization"] == "gguf"
     assert engine_args.load_format == "gguf"
 

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -68,11 +68,12 @@ def _patch_engine_args() -> None:
                 self.model_weights = gguf_model
             if self.served_model_name is None:
                 self.served_model_name = [gguf_model]
-            self.model = _get_gguf_config_source(
-                gguf_model,
-                self.tokenizer if isinstance(self.tokenizer, str) else None,
-                self.hf_config_path,
-            )
+            if self.hf_config_path is None:
+                self.hf_config_path = _get_gguf_config_source(
+                    gguf_model,
+                    self.tokenizer if isinstance(self.tokenizer, str) else None,
+                    None,
+                )
         return original_create_model_config(self, *args, **kwargs)
 
     EngineArgs.create_model_config = create_model_config


### PR DESCRIPTION
## Summary
Keep the GGUF reference in `EngineArgs.model` and move the original HF config source to `hf_config_path`.

This fixes the misleading startup logs reported in #11 without changing GGUF loading behavior.

## Why this is correct
- `ModelConfig` already prefers `hf_config_path` over `model` when resolving HF config.
- The GGUF weight path should remain the actual model reference so logs reflect the loaded weights.
- The tokenizer/original config source still gets used for config resolution, but no longer overwrites the model field.

## Changes
- Stop mutating `self.model` during the GGUF engine-args patch.
- Populate `self.hf_config_path` from the existing GGUF config source helper when it is not already set.
- Update the regression test to assert that `model` stays GGUF and `hf_config_path` carries the original config source.

## Verification
- `python3.12 -m py_compile vllm_gguf_plugin/plugin.py tests/test_plugin.py`
- Stubbed import harness covering the patched `EngineArgs.create_model_config()` path

## Related
- Closes #76
- Follows up on #11
