### PR TITLE
Validate missing GGUF config bundle early

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -19,6 +19,7 @@ from vllm.model_executor.model_loader import get_model_loader
 from vllm.transformers_utils.config import get_config_parser
 
 import vllm_gguf_plugin.config_parser as gguf_config_parser_module
+import vllm_gguf_plugin.plugin as gguf_plugin
 import vllm_gguf_plugin.quantization as gguf_quantization
 from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
@@ -234,6 +235,20 @@ def test_register_sets_engine_args_for_gguf_model(monkeypatch):
     assert captured["model_weights"] == "/tmp/model.gguf"
     assert captured["quantization"] == "gguf"
     assert engine_args.load_format == "gguf"
+
+
+def test_get_gguf_config_source_requires_local_config_bundle(
+    tmp_path, monkeypatch
+):
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+
+    monkeypatch.setattr(gguf_plugin, "check_gguf_file", lambda _model: True)
+    monkeypatch.setattr(gguf_plugin, "is_remote_gguf", lambda _model: False)
+    monkeypatch.setattr(gguf_plugin, "is_gguf", lambda _model: False)
+
+    with pytest.raises(ValueError, match="companion Hugging Face config files"):
+        gguf_plugin._get_gguf_config_source(str(gguf_path), None, None)
 
 
 def test_register_skips_speculator_probe_for_gguf():

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -24,6 +24,8 @@ from .weights_adapter.diffusion.integration import _patch_diffusers_loader
 OOTGGUFConfig = GGUFConfig
 OOTGGUFModelLoader = GGUFModelLoader
 
+_HF_CONFIG_FILENAME = "config.json"
+
 
 def _is_gguf_reference(model: str | None) -> bool:
     if not model:
@@ -44,7 +46,14 @@ def _get_gguf_config_source(
         repo_id, _ = split_remote_gguf(model)
         return repo_id
     if check_gguf_file(model):
-        return str(Path(model).parent)
+        config_dir = Path(model).parent
+        if not (config_dir / _HF_CONFIG_FILENAME).is_file():
+            raise ValueError(
+                "GGUF serving needs companion Hugging Face config files next "
+                f"to {model!r}. Add config.json alongside the GGUF file, or "
+                "pass the original model/tokenizer repo."
+            )
+        return str(config_dir)
     return model
 
 


### PR DESCRIPTION
Closes #25.

This PR adds an early error when a local GGUF file has no companion Hugging Face config bundle. Instead of failing later in config loading, it now stops immediately with a clear message.

Verification:
- py_compile on plugin.py and tests/test_plugin.py
- stubbed runtime check for _get_gguf_config_source with and without config.json
