### PR TITLE
Carry the CVE-2026-53923 fix (vllm #44971) into the migrated GGUF kernels

### DIFF
--- a/vllm_gguf_plugin/csrc/gguf/dequantize.cuh
+++ b/vllm_gguf_plugin/csrc/gguf/dequantize.cuh
@@ -78,8 +78,8 @@ static __device__ __forceinline__ void dequantize_q8_0(const void * vx, const in
 }
 
 template <int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
-static __global__ void dequantize_block(const void * __restrict__ vx, dst_t * __restrict__ y, const int k) {
-    const int i = 2*(blockDim.x*blockIdx.x + threadIdx.x);
+static __global__ void dequantize_block(const void * __restrict__ vx, dst_t * __restrict__ y, const int64_t k) {
+    const int64_t i = 2*((int64_t)blockDim.x*blockIdx.x + threadIdx.x);
 
     if (i >= k) {
         return;
@@ -435,91 +435,91 @@ static __global__ void dequantize_block_iq4_xs(const void * __restrict__ vx, dst
 }
 
 template <int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
-static void dequantize_block_cuda(const void * __restrict__ vx, dst_t * __restrict__ y, const int k, cudaStream_t stream) {
-    const int num_blocks = (k + 2*CUDA_DEQUANTIZE_BLOCK_SIZE - 1) / (2*CUDA_DEQUANTIZE_BLOCK_SIZE);
+static void dequantize_block_cuda(const void * __restrict__ vx, dst_t * __restrict__ y, const int64_t k, cudaStream_t stream) {
+    const int64_t num_blocks = (k + 2*CUDA_DEQUANTIZE_BLOCK_SIZE - 1) / (2*CUDA_DEQUANTIZE_BLOCK_SIZE);
     dequantize_block<qk, qr, dequantize_kernel><<<num_blocks, CUDA_DEQUANTIZE_BLOCK_SIZE, 0, stream>>>(vx, y, k);
 }
 
 template<typename dst_t>
-static void dequantize_row_q2_K_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_q2_K_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_q2_K<<<nb, 64, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_q3_K_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_q3_K_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_q3_K<<<nb, 64, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_q4_K_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_q4_K_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_q4_K<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_q5_K_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_q5_K_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_q5_K<<<nb, 64, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_q6_K_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_q6_K_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_q6_K<<<nb, 64, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq2_xxs_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq2_xxs_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq2_xxs<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq2_xs_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq2_xs_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq2_xs<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq2_s_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq2_s_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq2_s<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq3_xxs_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq3_xxs_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq3_xxs<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq3_s_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq3_s_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq3_s<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq1_s_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq1_s_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq1_s<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq1_m_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq1_m_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_iq1_m<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq4_nl_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq4_nl_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = (k + QK_K - 1) / QK_K;
     dequantize_block_iq4_nl<<<nb, 32, 0, stream>>>(vx, y);
 }
 
 template<typename dst_t>
-static void dequantize_row_iq4_xs_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+static void dequantize_row_iq4_xs_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = (k + QK_K - 1) / QK_K;
     dequantize_block_iq4_xs<<<nb, 32, 0, stream>>>(vx, y);
 }

--- a/vllm_gguf_plugin/csrc/gguf/ggml-common.h
+++ b/vllm_gguf_plugin/csrc/gguf/ggml-common.h
@@ -1064,7 +1064,7 @@ typedef half dfloat; // dequantize float
 typedef half2 dfloat2;
 typedef void (*dequantize_kernel_t)(const void * vx, const int ib, const int iqs, dfloat2 & v);
 template<typename dst_t>
-using to_cuda_ggml_t = void (*)(const void * __restrict__ x, dst_t * __restrict__ y, int k, cudaStream_t stream);
+using to_cuda_ggml_t = void (*)(const void * __restrict__ x, dst_t * __restrict__ y, int64_t k, cudaStream_t stream);
 typedef float (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs);
 typedef void (*allocate_tiles_cuda_t)(int ** x_ql, half2 ** x_dm, int ** x_qh, int ** x_sc);
 typedef void (*load_tiles_cuda_t)(

--- a/vllm_gguf_plugin/csrc/gguf/gguf_kernel.cu
+++ b/vllm_gguf_plugin/csrc/gguf/gguf_kernel.cu
@@ -90,7 +90,7 @@ Tensor ggml_dequantize(Tensor W,  // quant weight
   const int32_t device_idx = W.get_device_index();
   const DeviceGuard device_guard(device_idx);
   const auto dtype_ = dtype.value_or(ScalarType::Half);
-  Tensor DW = torch::stable::new_empty(W, {m, n}, dtype_);
+  Tensor DW = torch::stable::new_zeros(W, {m, n}, dtype_);
   cudaStream_t stream = get_current_cuda_stream(device_idx);
 
   VLLM_DISPATCH_FLOATING_TYPES(DW.scalar_type(), "ggml_dequantize", [&] {
@@ -104,12 +104,12 @@ Tensor ggml_dequantize(Tensor W,  // quant weight
 Tensor ggml_mul_mat_vec_a8(Tensor W,  // quant weight
                            Tensor X,  // input
                            int64_t type, int64_t row) {
-  int col = X.sizes()[1];
-  int vecs = X.sizes()[0];
-  const int padded = (col + 512 - 1) / 512 * 512;
+  int64_t col = X.sizes()[1];
+  int64_t vecs = X.sizes()[0];
+  const int64_t padded = (col + 512 - 1) / 512 * 512;
   const int32_t device_idx = X.get_device_index();
   const DeviceGuard device_guard(device_idx);
-  Tensor Y = torch::stable::new_empty(W, {vecs, row}, X.scalar_type());
+  Tensor Y = torch::stable::new_zeros(W, {vecs, row}, X.scalar_type());
   cudaStream_t stream = get_current_cuda_stream(device_idx);
   Tensor quant_X =
       torch::stable::new_empty(W, {vecs, padded / 32 * 9}, ScalarType::Int);
@@ -220,12 +220,12 @@ Tensor ggml_mul_mat_vec_a8(Tensor W,  // quant weight
 Tensor ggml_mul_mat_a8(Tensor W,  // quant weight
                        Tensor X,  // input
                        int64_t type, int64_t row) {
-  int col = X.sizes()[1];
-  int padded = (col + 512 - 1) / 512 * 512;
-  int batch = X.sizes()[0];
+  int64_t col = X.sizes()[1];
+  int64_t padded = (col + 512 - 1) / 512 * 512;
+  int64_t batch = X.sizes()[0];
   const int32_t device_idx = X.get_device_index();
   const DeviceGuard device_guard(device_idx);
-  Tensor Y = torch::stable::new_empty(W, {batch, row}, X.scalar_type());
+  Tensor Y = torch::stable::new_zeros(W, {batch, row}, X.scalar_type());
   cudaStream_t stream = get_current_cuda_stream(device_idx);
   Tensor quant_X =
       torch::stable::new_empty(W, {batch, padded / 32 * 9}, ScalarType::Int);
@@ -294,12 +294,12 @@ Tensor ggml_moe_a8(Tensor X,  // input
                    Tensor sorted_token_ids, Tensor expert_ids,
                    Tensor num_tokens_post_padded, int64_t type, int64_t row,
                    int64_t top_k, int64_t tokens) {
-  int col = X.sizes()[1];
-  int padded = (col + 512 - 1) / 512 * 512;
+  int64_t col = X.sizes()[1];
+  int64_t padded = (col + 512 - 1) / 512 * 512;
   const int32_t device_idx = X.get_device_index();
   const DeviceGuard device_guard(device_idx);
   Tensor Y =
-      torch::stable::new_empty(W, {tokens * top_k, row}, X.scalar_type());
+      torch::stable::new_zeros(W, {tokens * top_k, row}, X.scalar_type());
   cudaStream_t stream = get_current_cuda_stream(device_idx);
   Tensor quant_X =
       torch::stable::new_empty(W, {tokens, padded / 32 * 9}, ScalarType::Int);
@@ -396,8 +396,8 @@ Tensor ggml_moe_a8_vec(Tensor X,  // input
                        Tensor W,  // expert weights
                        Tensor topk_ids, int64_t top_k, int64_t type,
                        int64_t row, int64_t tokens) {
-  int col = X.sizes()[1];
-  const int padded = (col + 512 - 1) / 512 * 512;
+  int64_t col = X.sizes()[1];
+  const int64_t padded = (col + 512 - 1) / 512 * 512;
   const int32_t device_idx = X.get_device_index();
   const DeviceGuard device_guard(device_idx);
   Tensor Y =


### PR DESCRIPTION
# Carry the CVE-2026-53923 fix (vllm #44971) into the migrated GGUF kernels

## What this does

Ports the fix from vllm #44971 ("Fix info disclosure via int32 truncation in GGUF dequantize kernels", CVE-2026-53923) into `vllm_gguf_plugin/csrc/gguf/`. It has two parts:

1. Widen the dequant element-count and dimension math from 32-bit `int` to `int64_t` along the dequant path, so a large `m*n` (or `col` / `padded` / `batch` / `vecs`) can't truncate at the call boundary.
2. Zero-initialize the output buffers a kernel may only partially write, so the unwritten tail is zeros instead of stale device memory.

## Why it's needed

#44971 fixed CVE-2026-53923 in vllm (merged to `main` 2026-06-11, merge `f219788`). A day later, #39612 (`6635279`) moved the whole GGUF dequant kernel tree out of vllm into this plugin. The plugin was forked from a pre-#44971 snapshot and never got the fix, so `csrc/gguf/` still ships the vulnerable form. vllm core no longer carries these kernels, so the plugin is the GGUF dequant path that actually runs — which means the production path is unpatched for CVE-2026-53923 again.

State on `main` @ `acf0e6d` (tag `v0.0.3`, `base_version = 0.0.3`):

- `ggml-common.h`: the `to_cuda_ggml_t` dispatch typedef still declares the count param as `int k`.
- `dequantize.cuh`: `dequantize_block` takes `const int k` and computes `const int i = 2*(...)`; `dequantize_block_cuda` takes `const int k` / `const int num_blocks`; all 14 `dequantize_row_*_cuda` wrappers take `const int k`.
- `gguf_kernel.cu`: `ggml_mul_mat_vec_a8`, `ggml_mul_mat_a8`, and `ggml_moe_a8` read `col`/`padded`/`batch`/`vecs` as 32-bit `int`; and `ggml_dequantize`, `ggml_mul_mat_vec_a8`, `ggml_mul_mat_a8`, `ggml_moe_a8` allocate their output with `new_empty` and never zero it.

Two spots have already drifted toward the fix, and I left those halves alone:

- `ggml_dequantize` already takes `int64_t m, int64_t n`, so its index math is 64-bit — it only needed the zero-init.
- `ggml_moe_a8_vec` already allocates with `new_zeros` — it only needed the dim widening.

## The risk

The dequant kernels write `k = m*n` elements (or the mat-mul equivalent). When that count is computed or passed as 32-bit `int`, a tensor with more than `INT_MAX` elements truncates it, and the kernel launches for fewer elements than the output holds. The output is allocated with `new_empty` (uninitialized device memory) and never zeroed, so the unwritten tail keeps whatever previously used that allocation. Where multiple untrusted tenants' GGUF models share one GPU, that tail can hold another tenant's residual data — a bounded cross-tenant information leak (CWE-190 truncation → CWE-908 uninitialized resource). It isn't RCE, and the residue is only observable when untrusted tenants share a device. Same boundary and severity as the original CVE-2026-53923.

## The change

A faithful, minimal port of #44971 — no refactor, no new behavior:

- `ggml-common.h`: `to_cuda_ggml_t` count param `int k` → `int64_t k`.
- `dequantize.cuh`: `dequantize_block` `k` and index `i` → `int64_t` (with the `(int64_t)` cast on the index, as upstream); `dequantize_block_cuda` `k` and `num_blocks` → `int64_t`; the 14 `dequantize_row_*_cuda` `k` params → `int64_t`. The per-block `nb = k / QK_K` locals stay `int`, matching upstream (`nb` is bounded by the CUDA grid limit).
- `gguf_kernel.cu`: widen `col`/`padded`/`batch`/`vecs` locals to `int64_t` in `ggml_mul_mat_vec_a8`, `ggml_mul_mat_a8`, `ggml_moe_a8`, `ggml_moe_a8_vec`; zero-init the returned output in `ggml_dequantize`, `ggml_mul_mat_vec_a8`, `ggml_mul_mat_a8`, `ggml_moe_a8`.

For the zero-init I used the plugin's own `torch::stable::new_zeros(...)` rather than upstream's `empty(...)` + `fill_(..., 0.0)`. It's behaviorally the same (allocate + zero) and already the pattern `ggml_moe_a8_vec` uses, so it matches local style. Glad to switch to an explicit `fill_` if you'd rather mirror the upstream diff line for line. The internal `quant_X` scratch buffers stay `new_empty` — they're fully overwritten by `quantize_row_q8_1_cuda`, and #44971 didn't zero them either.

## Test status

Being straight about this:

- The diff applies cleanly to `main` @ `acf0e6d` (`git apply --check` passes).
- It's a line-faithful port of the upstream fix, adjusted for the two spots this plugin had already partly updated.
- I have not compiled or run it. These are CUDA `.cu` kernels and I don't have a CUDA build environment on hand, so this is source-level review only.
- I'm happy to (a) provide a benign residue repro — load a GGUF whose dequant output exceeds `INT_MAX` elements on a device with dirtied memory, read the output tail, and show non-zero residue before the patch vs. zeros after — or (b) let CI build and run the kernel tests. Point me at whichever you prefer.

## References

- CVE-2026-53923 (GHSA-5jv2-g5wq-cmr4) — GGUF dequant integer-truncation residue leak.
- vllm #44971 — the canonical fix (merge `f219788`).
- vllm #39612 (`6635279`) — the migration that moved the GGUF kernels into this plugin, after #44971 merged, without carrying the fix.
