### PR TITLE
[Bugfix] Fix ggml_moe_a8 fake registration dtype for bf16 inputs

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -431,33 +431,3 @@ def test_moe_triton(
         x, w13_dequant, w2_dequant, topk_weights, topk_ids
     ).reshape(output.shape)
     torch.testing.assert_close(output, ref_output, atol=1, rtol=1e-1)
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_moe_a8_fake_dtype_matches_kernel(dtype):
-    # The CUDA kernel allocates its output with X's dtype
-    # (csrc/gguf/gguf_kernel.cu ggml_moe_a8), so the fake registration must
-    # do the same or torch.compile traces the wrong dtype for bf16 models.
-    from torch._subclasses.fake_tensor import FakeTensorMode
-
-    quant_type = GGMLQuantizationType.Q4_K
-    with FakeTensorMode():
-        X = torch.empty((8, 512), dtype=dtype, device="cuda")
-        W = torch.empty((4, 1024, 288), dtype=torch.uint8, device="cuda")
-        sorted_token_ids = torch.empty((64,), dtype=torch.int32, device="cuda")
-        expert_ids = torch.empty((2,), dtype=torch.int32, device="cuda")
-        num_tokens_post_padded = torch.empty((1,), dtype=torch.int32, device="cuda")
-        out = torch.ops._C_gguf.ggml_moe_a8(
-            X,
-            W,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            quant_type,
-            1024,
-            2,
-            8,
-        )
-    assert out.dtype == dtype
-    assert out.shape == (16, 1024)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -431,3 +431,33 @@ def test_moe_triton(
         x, w13_dequant, w2_dequant, topk_weights, topk_ids
     ).reshape(output.shape)
     torch.testing.assert_close(output, ref_output, atol=1, rtol=1e-1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_moe_a8_fake_dtype_matches_kernel(dtype):
+    # The CUDA kernel allocates its output with X's dtype
+    # (csrc/gguf/gguf_kernel.cu ggml_moe_a8), so the fake registration must
+    # do the same or torch.compile traces the wrong dtype for bf16 models.
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    quant_type = GGMLQuantizationType.Q4_K
+    with FakeTensorMode():
+        X = torch.empty((8, 512), dtype=dtype, device="cuda")
+        W = torch.empty((4, 1024, 288), dtype=torch.uint8, device="cuda")
+        sorted_token_ids = torch.empty((64,), dtype=torch.int32, device="cuda")
+        expert_ids = torch.empty((2,), dtype=torch.int32, device="cuda")
+        num_tokens_post_padded = torch.empty((1,), dtype=torch.int32, device="cuda")
+        out = torch.ops._C_gguf.ggml_moe_a8(
+            X,
+            W,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            quant_type,
+            1024,
+            2,
+            8,
+        )
+    assert out.dtype == dtype
+    assert out.shape == (16, 1024)

--- a/vllm_gguf_plugin/ops.py
+++ b/vllm_gguf_plugin/ops.py
@@ -153,8 +153,10 @@ if (
         top_k: torch.SymInt,
         tokens: torch.SymInt,
     ) -> torch.Tensor:
+        # match the CUDA kernel, which allocates its output with X's dtype
+        # (see csrc/gguf/gguf_kernel.cu ggml_moe_a8: new_empty(..., X.scalar_type()))
         return torch.empty(
-            (X.size(0) * top_k, row), dtype=torch.float16, device=W.device
+            (X.size(0) * top_k, row), dtype=X.dtype, device=W.device
         )
 
 

--- a/vllm_gguf_plugin/ops.py
+++ b/vllm_gguf_plugin/ops.py
@@ -153,11 +153,7 @@ if (
         top_k: torch.SymInt,
         tokens: torch.SymInt,
     ) -> torch.Tensor:
-        # match the CUDA kernel, which allocates its output with X's dtype
-        # (see csrc/gguf/gguf_kernel.cu ggml_moe_a8: new_empty(..., X.scalar_type()))
-        return torch.empty(
-            (X.size(0) * top_k, row), dtype=X.dtype, device=W.device
-        )
+        return torch.empty((X.size(0) * top_k, row), dtype=X.dtype, device=W.device)
 
 
 if (


### PR DESCRIPTION
## Purpose

The CUDA kernel `ggml_moe_a8` allocates its output with the input's dtype (`csrc/gguf/gguf_kernel.cu`: `new_empty(W, {tokens * top_k, row}, X.scalar_type())`, dispatched via `VLLM_DISPATCH_FLOATING_TYPES`), but the fake registration in `ops.py` hardcodes `torch.float16`:

```python
@register_fake("_C_gguf::ggml_moe_a8")
def _ggml_moe_a8_fake(...):
    return torch.empty((X.size(0) * top_k, row), dtype=torch.float16, device=W.device)
```

For bf16 GGUF models (supported since #73 removed the Blackwell bf16 restriction), torch.compile and any FakeTensor based tracing see fp16 where the kernel produces bf16, so the wrong dtype propagates through the traced graph. The sibling `_ggml_moe_a8_vec_fake` already uses `X.dtype`. This PR returns `X.dtype` in the fake to match the kernel contract.

Verified against the compiled extension on an A100, before and after:

```
BEFORE: fake dtype = torch.float16 | input = torch.bfloat16 | mismatch
AFTER:  fake dtype = torch.bfloat16 | matches kernel contract
```

## Test Plan / Test Result

New FakeTensorMode regression test parametrized over fp16 and bf16, asserting the fake's dtype and shape match the kernel contract:

```
pytest tests/test_kernels.py -k fake_dtype
2 passed, 2094 deselected in 22.08s
```

Process note: developed with an agentic AI workflow (Claude) under my direction, following a spec, implement, verify loop: the mismatch was identified by auditing the fake registrations against the kernel source, the fix and regression test were drafted agentically, and I validated the before and after behavior against the compiled extension on an A100 prior to opening this PR. Co-authored-by trailer on the commit.
