### PR TITLE
Fix ROCm 7.x build failure: drop CUDA-only --use_fast_math from hipified nvcc args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,20 @@ def _should_build_extension() -> bool:
 setup_kwargs: dict = {"version": _package_version()}
 
 if _should_build_extension():
+    import torch
     from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+    is_rocm = getattr(torch.version, "hip", None) is not None
+
+    nvcc_args = [
+        "-O3",
+        "-std=c++17",
+        # Exposes aoti_torch_get_current_cuda_stream in the AOTI shim.
+        "-DUSE_CUDA",
+    ]
+    if not is_rocm:
+        # hipcc (ROCm 7.x) rejects nvcc-only flags like --use_fast_math.
+        nvcc_args.insert(2, "--use_fast_math")
 
     setup_kwargs.update(
         ext_modules=[
@@ -43,13 +56,7 @@ if _should_build_extension():
                 py_limited_api=True,
                 extra_compile_args={
                     "cxx": ["-O3", "-std=c++17"],
-                    "nvcc": [
-                        "-O3",
-                        "-std=c++17",
-                        "--use_fast_math",
-                        # Exposes aoti_torch_get_current_cuda_stream in the AOTI shim.
-                        "-DUSE_CUDA",
-                    ],
+                    "nvcc": nvcc_args,
                 },
             )
         ],


### PR DESCRIPTION
## Summary
- `setup.py` hardcodes `--use_fast_math` in the `nvcc` extra_compile_args for the
  `CUDAExtension`. When building against a ROCm PyTorch install, this source file
  gets hipified to `.hip` and compiled via `hipcc`, but the `nvcc` args are passed
  through unchanged.
- On ROCm 7.x, `hipcc`'s frontend is plain `clang++`, which does not recognize
  `--use_fast_math` (it's an nvcc-only flag). This causes the build to fail with
  `clang++: error: unknown argument: '--use_fast_math'` on any ROCm 7.x toolchain
  (tested against ROCm 7.2 on gfx1100 / RX 7900 XTX).
- This patch detects the backend via `torch.version.hip` and only appends
  `--use_fast_math` to the nvcc args when building for CUDA, leaving the CUDA
  build path unchanged.

## Why not a duplicate
Searched open issues/PRs on vllm-project/vllm-gguf-plugin for "use_fast_math",
"ROCm", "hipcc", and "gfx1100" — found no existing report or fix for this build
failure at the time of writing.

## Test plan
- [x] `uv pip install --no-build-isolation -e . --torch-backend=rocm7.2`
      completes without error on ROCm 7.2 / gfx1100 (previously failed with
      `clang++: error: unknown argument: '--use_fast_math'`; hipify log confirms
      0 unsupported CUDA calls, 94 kernel launches replaced successfully)
- [x] Plugin loads successfully under vLLM: `vllm serve <gguf-model>` no longer
      raises `Failed to load plugin gguf` / `ModuleNotFoundError: No module named
      'gguf'`; logs show
      `Registered model loader <class 'vllm_gguf_plugin.loader.GGUFModelLoader'>`
      and `Registered config parser <class 'vllm_gguf_plugin.config_parser.GGUFConfigParser'>`
- [x] End-to-end generation (`vllm serve unsloth/Qwen3-0.6B-GGUF:Q4_K_M --tokenizer
      Qwen/Qwen3-0.6B`) — This has been verified. Successful.