### PR TITLE
[Doc] Document tested GGUF model coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,29 @@ The same hooks also run in GitHub Actions on every push and pull request.
 ```bash
 vllm serve Qwen/Qwen3-0.6B-GGUF:Q8_0 --tokenizer Qwen/Qwen3-0.6B
 ```
+
+## Tested model coverage
+
+The plugin uses vLLM's model implementations and a generic GGUF weight
+adapter, so model compatibility is broader than a fixed allowlist. The models
+below are covered by the repository's generation tests and are the best-known
+starting points:
+
+| Modality | Model family | Tested GGUF quantization |
+| --- | --- | --- |
+| Text | Qwen 2.5 | Q6_K |
+| Text | Qwen 3 | Q8_0 |
+| Text | Phi 3.5 | IQ4_XS |
+| Text | GPT-2 | Q4_K_M |
+| Text | StableLM | Q4_K_M |
+| Text | Gemma 3 | Q4_0 |
+| Text | OLMoE | Q4_0 |
+| Vision-language | Gemma 3 | Q4_0 backbone with F16 projector |
+| Image generation | Z-Image-Turbo | Q4_0 |
+| Image generation | FLUX.2-klein | Q8_0 |
+
+Other vLLM-supported architectures may work when their GGUF tensor names map
+to the corresponding Hugging Face model. A model appearing in vLLM's general
+supported-model list does not by itself guarantee GGUF compatibility. When
+reporting an unsupported model, include the model repository, quantization,
+plugin and vLLM versions, and the complete weight-mapping error.


### PR DESCRIPTION
## Summary

Document the model families and GGUF quantizations exercised by this repository's generation tests. The new table covers text, vision-language, and image-generation paths and gives users a practical starting point without presenting the list as a hard compatibility allowlist.

The surrounding guidance also explains why general vLLM architecture support does not by itself guarantee GGUF weight mapping, and asks unsupported-model reports to include the details maintainers need to investigate.

Closes #75.

## Validation

- `uvx pre-commit run --all-files`
  - Ruff check and format
  - typos
  - clang-format
  - markdownlint-cli2
  - filename check
- `git diff --check`
- Runtime/GPU tests were not run because this is a README-only change and the validation host does not have a CUDA toolkit.

## AI assistance

OpenAI Codex assisted with repository research, drafting, and validation. I reviewed every changed line and confirm that I understand the documentation and its limitations. Codex cross-checked the table against the repository's generation tests and ran the checks above under my supervision. I take responsibility for the contribution. The commit includes both AI attribution and my DCO sign-off.