### PR TITLE
feat: support Qwen3.5/3.6 GGUF with vision and MTP speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ starting points:
 | Text | Gemma 3 | Q4_0 |
 | Text | OLMoE | Q4_0 |
 | Vision-language | Gemma 3 | Q4_0 backbone with F16 projector |
+| Vision-language | Qwen 3.5 | Q4_0 backbone with BF16 projector |
+| Vision-language | Qwen 3.6 | UD-IQ2_XXS backbone with BF16 projector |
 | Image generation | Z-Image-Turbo | Q4_0 |
 | Image generation | FLUX.2-klein | Q8_0 |
 

--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -122,11 +123,13 @@ class TestGGUFModelLoader:
         model_config = MagicMock()
         model_config.model_weights = "unsloth/Qwen3-0.6B-GGUF/model.gguf"
         model_config.model = "unsloth/Qwen3-0.6B-GGUF"
+        model_config.revision = None
+        model_config.hf_config = SimpleNamespace()
 
         result = loader._prepare_weights(model_config)
         assert result == "/downloaded/model.gguf"
         mock_hf_download.assert_called_once_with(
-            repo_id="unsloth/Qwen3-0.6B-GGUF", filename="model.gguf"
+            repo_id="unsloth/Qwen3-0.6B-GGUF", filename="model.gguf", revision=None
         )
 
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
@@ -150,10 +153,46 @@ class TestGGUFModelLoader:
         model_config.model_weights = "unsloth/Qwen3-0.6B-GGUF:IQ1_S"
         model_config.model = "unsloth/Qwen3-0.6B-GGUF"
         model_config.revision = None
+        model_config.hf_config = SimpleNamespace()
 
         result = loader._prepare_weights(model_config)
         assert result == f"{mock_folder}/model-IQ1_S.gguf"
         mock_download.assert_called_once()
+
+    @patch("vllm_gguf_plugin.weight_utils.hf_hub_download")
+    @patch("vllm_gguf_plugin.weight_utils.list_filtered_repo_files")
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    @patch("glob.glob")
+    @patch("os.path.isdir", return_value=False)
+    @patch("os.path.isfile", return_value=False)
+    def test_prepare_weights_fetches_one_mmproj_for_multimodal(
+        self, mock_isfile, mock_isdir, mock_glob, mock_download, mock_list, mock_hf
+    ):
+        """A multimodal config also pulls the projector — which the quant-type
+        patterns of download_gguf never match — but only one precision of it."""
+        mock_folder = "/tmp/mock_cache"
+        mock_download.return_value = mock_folder
+        mock_glob.side_effect = lambda pattern, **kwargs: (
+            [f"{mock_folder}/model-IQ1_S.gguf"] if "IQ1_S" in pattern else []
+        )
+        mock_list.return_value = ["mmproj-F32.gguf", "mmproj-BF16.gguf"]
+
+        loader = GGUFModelLoader(LoadConfig(load_format="gguf"))
+
+        model_config = MagicMock()
+        model_config.model_weights = "unsloth/Qwen3.5-0.8B-GGUF:IQ1_S"
+        model_config.model = "unsloth/Qwen3.5-0.8B-GGUF"
+        model_config.revision = None
+        model_config.hf_config = SimpleNamespace(vision_config=SimpleNamespace())
+
+        result = loader._prepare_weights(model_config)
+        assert result == f"{mock_folder}/model-IQ1_S.gguf"
+        mock_hf.assert_called_once_with(
+            repo_id="unsloth/Qwen3.5-0.8B-GGUF",
+            filename="mmproj-BF16.gguf",
+            cache_dir=None,
+            revision=None,
+        )
 
     @patch("os.path.isfile", return_value=False)
     def test_prepare_weights_invalid_format(self, mock_isfile):

--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -123,13 +123,11 @@ class TestGGUFModelLoader:
         model_config = MagicMock()
         model_config.model_weights = "unsloth/Qwen3-0.6B-GGUF/model.gguf"
         model_config.model = "unsloth/Qwen3-0.6B-GGUF"
-        model_config.revision = None
-        model_config.hf_config = SimpleNamespace()
 
         result = loader._prepare_weights(model_config)
         assert result == "/downloaded/model.gguf"
         mock_hf_download.assert_called_once_with(
-            repo_id="unsloth/Qwen3-0.6B-GGUF", filename="model.gguf", revision=None
+            repo_id="unsloth/Qwen3-0.6B-GGUF", filename="model.gguf"
         )
 
     @patch("vllm_gguf_plugin.weight_utils.snapshot_download")

--- a/tests/test_gguf_utils.py
+++ b/tests/test_gguf_utils.py
@@ -251,3 +251,59 @@ class TestExtractLMHeadFromGGUF:
         ]
 
         assert extract_lm_head_from_gguf("/tmp/model.gguf")
+
+
+class TestMaybePatchQwen35Config:
+    @patch("vllm_gguf_plugin.gguf_utils.detect_gguf_multimodal", return_value=None)
+    @patch("vllm_gguf_plugin.gguf_utils.extract_lm_head_from_gguf", return_value=None)
+    @patch(
+        "vllm_gguf_plugin.gguf_utils.extract_vocab_size_from_gguf",
+        return_value=None,
+    )
+    @pytest.mark.parametrize(
+        ("model_type", "architecture"),
+        [
+            ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+            ("qwen3_5_text", "Qwen3_5ForConditionalGeneration"),
+            ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+            ("qwen3_5_moe_text", "Qwen3_5MoeForConditionalGeneration"),
+        ],
+    )
+    def test_enforces_conditional_arch_without_mmproj(
+        self, _mock_vocab, _mock_lm_head, _mock_detect, model_type, architecture
+    ):
+        from transformers import PretrainedConfig
+
+        from vllm_gguf_plugin.gguf_utils import maybe_patch_hf_config_from_gguf
+
+        config = PretrainedConfig(
+            model_type=model_type, architectures=["Qwen3_5ForCausalLM"]
+        )
+        patched = maybe_patch_hf_config_from_gguf("/tmp/model.gguf", config)
+
+        assert patched.architectures == [architecture]
+
+    @patch(
+        "vllm_gguf_plugin.gguf_utils.extract_vision_config_from_gguf",
+        return_value=None,
+    )
+    @patch(
+        "vllm_gguf_plugin.gguf_utils.detect_gguf_multimodal",
+        return_value=Path("/tmp/mmproj.gguf"),
+    )
+    @patch("vllm_gguf_plugin.gguf_utils.extract_lm_head_from_gguf", return_value=None)
+    @patch(
+        "vllm_gguf_plugin.gguf_utils.extract_vocab_size_from_gguf",
+        return_value=None,
+    )
+    def test_upgrades_text_config_to_multimodal_with_mmproj(self, *_mocks):
+        from transformers import PretrainedConfig
+
+        from vllm_gguf_plugin.gguf_utils import maybe_patch_hf_config_from_gguf
+
+        config = PretrainedConfig(model_type="qwen3_5_text")
+        patched = maybe_patch_hf_config_from_gguf("/tmp/model.gguf", config)
+
+        assert patched.model_type == "qwen3_5"
+        assert patched.vision_config is not None
+        assert patched.architectures == ["Qwen3_5ForConditionalGeneration"]

--- a/tests/test_multimodal_gguf.py
+++ b/tests/test_multimodal_gguf.py
@@ -94,7 +94,47 @@ GEMMA3_CONFIG_PAN_AND_SCAN = GGUFMMTestConfig(
     mm_processor_kwargs={"do_pan_and_scan": True},
 )
 
-MODELS_TO_TEST = [GEMMA3_CONFIG, GEMMA3_CONFIG_PAN_AND_SCAN]
+# Qwen3.5 multimodal GGUF — natively multimodal (shared arch for text + vision)
+_QWEN35_PROMPTS = [
+    (
+        "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>"
+        "What's the content in the center of the image?"
+        "<|im_end|>\n<|im_start|>assistant\n"
+    ),
+    (
+        "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>"
+        "What is the season?"
+        "<|im_end|>\n<|im_start|>assistant\n"
+    ),
+]
+_QWEN35_IMAGE_NAMES = ["stop_sign", "cherry_blossom"]
+
+QWEN35_CONFIG = GGUFMMTestConfig(
+    original_model="Qwen/Qwen3.5-0.8B",
+    gguf_repo="unsloth/Qwen3.5-0.8B-GGUF",
+    gguf_backbone="Qwen3.5-0.8B-Q4_K_M.gguf",
+    gguf_mmproj="mmproj-BF16.gguf",
+    prompt=_QWEN35_PROMPTS,
+    image_names=_QWEN35_IMAGE_NAMES,
+    max_model_len=4096,
+)
+
+# Qwen3.5-MoE multimodal GGUF (large weights + HF baseline)
+QWEN35_MOE_CONFIG = GGUFMMTestConfig(
+    original_model="Qwen/Qwen3.5-35B-A3B",
+    gguf_repo="unsloth/Qwen3.5-35B-A3B-GGUF",
+    gguf_backbone="Qwen3.5-35B-A3B-Q4_K_M.gguf",
+    gguf_mmproj="mmproj-BF16.gguf",
+    prompt=_QWEN35_PROMPTS,
+    image_names=_QWEN35_IMAGE_NAMES,
+    max_model_len=4096,
+    marks=[pytest.mark.slow],
+)
+
+GEMMA3_MODELS_TO_TEST = [GEMMA3_CONFIG, GEMMA3_CONFIG_PAN_AND_SCAN]
+QWEN35_MODELS_TO_TEST = [QWEN35_CONFIG, QWEN35_MOE_CONFIG]
 
 
 def _vllm_generate_greedy_logprobs(
@@ -315,13 +355,36 @@ def run_multimodal_gguf_test(
     "model",
     [
         pytest.param(test_config, marks=test_config.marks)
-        for test_config in MODELS_TO_TEST
+        for test_config in GEMMA3_MODELS_TO_TEST
     ],
 )
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("max_tokens", [MAX_TOKENS])
 @pytest.mark.parametrize("num_logprobs", [NUM_LOGPROBS])
 def test_gemma3_mm_gguf(
+    model: GGUFMMTestConfig,
+    dtype: str,
+    max_tokens: int,
+    num_logprobs: int,
+) -> None:
+    run_multimodal_gguf_test(model, dtype, max_tokens, num_logprobs)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for multimodal GGUF tests.",
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(test_config, marks=test_config.marks)
+        for test_config in QWEN35_MODELS_TO_TEST
+    ],
+)
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+@pytest.mark.parametrize("max_tokens", [MAX_TOKENS])
+@pytest.mark.parametrize("num_logprobs", [NUM_LOGPROBS])
+def test_qwen35_mm_gguf(
     model: GGUFMMTestConfig,
     dtype: str,
     max_tokens: int,

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+from vllm.model_executor.utils import set_weight_attrs
+
+from vllm_gguf_plugin.quantization.params import (
+    GGUFUninitializedWeightTypeParameter,
+    _resolve_gguf_weight_type_loader,
+)
+
+
+class _Layer:
+    """Layer stub without weight_loader_v2."""
+
+
+def _make_qweight_type(num_elements: int):
+    param = GGUFUninitializedWeightTypeParameter(requires_grad=False)
+    set_weight_attrs(
+        param,
+        {
+            "weight_type": 0,
+            "shard_weight_type": {},
+            "num_elements": num_elements,
+            "ignore_warning": True,
+        },
+    )
+    return param
+
+
+def _fail_base_loader(*args, **kwargs):
+    pytest.fail("base weight loader should not be called")
+
+
+def test_weight_type_loader_stores_scalar_without_shard_id():
+    loader = _resolve_gguf_weight_type_loader(_Layer(), _fail_base_loader)
+    param = _make_qweight_type(num_elements=1)
+
+    loader(param, torch.tensor(7))
+
+    assert param.weight_type == 7
+
+
+def test_weight_type_loader_stores_tuple_shard_ids():
+    """Fused GGUF weight type covering multiple shards (e.g. Qwen3.5 GDN
+    in_proj_qkv → in_proj_qkvz shards (0, 1, 2))."""
+    loader = _resolve_gguf_weight_type_loader(_Layer(), _fail_base_loader)
+    param = _make_qweight_type(num_elements=4)
+
+    loader(param, torch.tensor(8), (0, 1, 2))
+
+    assert param.shard_weight_type == {0: 8, 1: 8, 2: 8}
+    assert param.weight_type == 8

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.model_executor.layers.vocab_parallel_embedding as vocab_embedding_module
@@ -214,6 +215,44 @@ def test_gguf_config_parser_uses_parent_dir_for_local_file(tmp_path, monkeypatch
     assert calls["trust_remote_code"] is False
     assert config_dict["norm_topk_prob"] is True
     assert config.architectures == ["Qwen3MoeForCausalLM"]
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architecture"),
+    [
+        ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+        ("qwen3_5_text", "Qwen3_5ForConditionalGeneration"),
+        ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+        ("qwen3_5_moe_text", "Qwen3_5MoeForConditionalGeneration"),
+    ],
+)
+def test_gguf_config_parser_uses_conditional_arch_for_qwen35(
+    tmp_path, monkeypatch, model_type, architecture
+):
+    """Qwen3.5 has no ForCausalLM entry in the vLLM model registry."""
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+
+    def fake_parse(
+        self, model, trust_remote_code, revision=None, code_revision=None, **kwargs
+    ):
+        return {}, PretrainedConfig(model_type=model_type)
+
+    monkeypatch.setattr(
+        gguf_config_parser_module.HFConfigParser,
+        "parse",
+        fake_parse,
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda model, config: config,
+    )
+
+    config_dict, config = GGUFConfigParser().parse(gguf_path, trust_remote_code=False)
+
+    assert config_dict["architectures"] == [architecture]
+    assert config.architectures == [architecture]
 
 
 def test_register_sets_engine_args_for_gguf_model(monkeypatch):

--- a/tests/test_qwen3_5_adapter.py
+++ b/tests/test_qwen3_5_adapter.py
@@ -112,13 +112,22 @@ class TestTransformWeights:
         out = self._transform(adapter, [(name, torch.zeros(16))])
         assert out[name].shape == (16,)
 
-    def test_expands_patch_embed_temporal_dim(self):
+    def test_stacks_patch_embed_temporal_slices(self):
         adapter = self._make_adapter(temporal_patch_size=2)
         name = "model.visual.patch_embed.proj.weight"
-        weight = torch.ones(8, 3, 14, 14)
-        out = self._transform(adapter, [(name, weight)])
+        first, second = torch.ones(8, 3, 14, 14), torch.zeros(8, 3, 14, 14)
+        out = self._transform(adapter, [(name, first), (f"{name}.1", second)])
+        assert list(out) == [name]
         assert out[name].shape == (8, 3, 2, 14, 14)
-        assert torch.allclose(out[name].sum(dim=2), weight)
+        assert torch.equal(out[name][:, :, 0], first)
+        assert torch.equal(out[name][:, :, 1], second)
+
+    def test_stacks_patch_embed_slices_out_of_order(self):
+        adapter = self._make_adapter(temporal_patch_size=2)
+        name = "model.visual.patch_embed.proj.weight"
+        first, second = torch.ones(8, 3, 14, 14), torch.zeros(8, 3, 14, 14)
+        out = self._transform(adapter, [(f"{name}.1", second), (name, first)])
+        assert torch.equal(out[name][:, :, 0], first)
 
     def test_keeps_patch_embed_without_temporal_expansion(self):
         adapter = self._make_adapter(temporal_patch_size=1)

--- a/tests/test_qwen3_5_adapter.py
+++ b/tests/test_qwen3_5_adapter.py
@@ -2,12 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from types import SimpleNamespace
 
+import gguf
 import pytest
 import torch
 from transformers import PretrainedConfig
 
+from vllm_gguf_plugin.weight_utils import split_stacked_experts
 from vllm_gguf_plugin.weights_adapter import get_weights_adapter
-from vllm_gguf_plugin.weights_adapter.qwen3_5 import Qwen35GGUFAdapter
+from vllm_gguf_plugin.weights_adapter.qwen3_5 import (
+    Qwen35GGUFAdapter,
+    build_qwen35_text_mapper,
+    build_qwen35_vision_mapper,
+)
 
 
 class TestMatches:
@@ -26,24 +32,211 @@ class TestMatches:
         assert not Qwen35GGUFAdapter.matches(config)
 
 
-class TestMergerNameMap:
-    def test_maps_merger_tensors(self):
-        name_map = {}
-        Qwen35GGUFAdapter._map_qwen35_merger(name_map)
-        assert name_map == {
-            "mm.0.weight": "model.visual.merger.linear_fc1.weight",
-            "mm.0.bias": "model.visual.merger.linear_fc1.bias",
-            "mm.2.weight": "model.visual.merger.linear_fc2.weight",
-            "mm.2.bias": "model.visual.merger.linear_fc2.bias",
-            # llama.cpp writes merger.norm as v.post_ln, not mm.input_norm
-            "v.post_ln.weight": "model.visual.merger.norm.weight",
-            "v.post_ln.bias": "model.visual.merger.norm.bias",
+class TestTextMapper:
+    def _map(self, name, is_multimodal=False, is_moe=False):
+        mapper = build_qwen35_text_mapper(is_multimodal=is_multimodal, is_moe=is_moe)
+        return mapper.apply_list([name])[0]
+
+    @pytest.mark.parametrize(
+        ("gguf_name", "hf_name"),
+        [
+            ("token_embd.weight", "model.embed_tokens.weight"),
+            ("output_norm.weight", "model.norm.weight"),
+            ("output.weight", "lm_head.weight"),
+            ("blk.3.attn_q.weight", "model.layers.3.self_attn.q_proj.weight"),
+            ("blk.3.attn_q_norm.weight", "model.layers.3.self_attn.q_norm.weight"),
+            ("blk.3.attn_norm.weight", "model.layers.3.input_layernorm.weight"),
+            (
+                "blk.3.post_attention_norm.weight",
+                "model.layers.3.post_attention_layernorm.weight",
+            ),
+            # GDN: llama.cpp writes the fused in_proj halves as attn_qkv/attn_gate
+            (
+                "blk.3.attn_qkv.weight",
+                "model.layers.3.linear_attn.in_proj_qkv.weight",
+            ),
+            ("blk.3.attn_gate.weight", "model.layers.3.linear_attn.in_proj_z.weight"),
+            ("blk.3.ssm_alpha.weight", "model.layers.3.linear_attn.in_proj_a.weight"),
+            ("blk.3.ssm_beta.weight", "model.layers.3.linear_attn.in_proj_b.weight"),
+            ("blk.3.ssm_out.weight", "model.layers.3.linear_attn.out_proj.weight"),
+            ("blk.3.ssm_norm.weight", "model.layers.3.linear_attn.norm.weight"),
+            ("blk.3.ssm_conv1d.weight", "model.layers.3.linear_attn.conv1d.weight"),
+            # these two are bare params in the HF checkpoint
+            ("blk.3.ssm_a.weight", "model.layers.3.linear_attn.A_log"),
+            ("blk.3.ssm_dt.bias", "model.layers.3.linear_attn.dt_bias"),
+        ],
+    )
+    def test_maps_text_tensors(self, gguf_name, hf_name):
+        assert self._map(gguf_name) == hf_name
+
+    def test_multimodal_uses_language_model_prefix(self):
+        assert (
+            self._map("blk.3.attn_q.weight", is_multimodal=True)
+            == "model.language_model.layers.3.self_attn.q_proj.weight"
+        )
+        assert self._map("output.weight", is_multimodal=True) == "lm_head.weight"
+
+    @pytest.mark.parametrize(
+        ("gguf_name", "hf_name"),
+        [
+            ("blk.1.ffn_gate.weight", "model.layers.1.mlp.gate_proj.weight"),
+            ("blk.1.ffn_up.weight", "model.layers.1.mlp.up_proj.weight"),
+            ("blk.1.ffn_down.weight", "model.layers.1.mlp.down_proj.weight"),
+        ],
+    )
+    def test_maps_dense_mlp(self, gguf_name, hf_name):
+        assert self._map(gguf_name) == hf_name
+
+    @pytest.mark.parametrize(
+        ("gguf_name", "hf_name"),
+        [
+            ("blk.1.ffn_gate_inp.weight", "model.layers.1.mlp.gate.weight"),
+            (
+                "blk.1.ffn_gate_inp_shexp.weight",
+                "model.layers.1.mlp.shared_expert_gate.weight",
+            ),
+            (
+                "blk.1.ffn_gate_exps.weight",
+                "model.layers.1.mlp.experts.0.gate_proj.weight",
+            ),
+            ("blk.1.ffn_up_exps.weight", "model.layers.1.mlp.experts.0.up_proj.weight"),
+            (
+                "blk.1.ffn_down_exps.weight",
+                "model.layers.1.mlp.experts.0.down_proj.weight",
+            ),
+            (
+                "blk.1.ffn_up_shexp.weight",
+                "model.layers.1.mlp.shared_expert.up_proj.weight",
+            ),
+        ],
+    )
+    def test_maps_moe_mlp(self, gguf_name, hf_name):
+        assert self._map(gguf_name, is_moe=True) == hf_name
+
+    def test_maps_quantized_names_like_plain_ones(self):
+        assert (
+            self._map("blk.3.attn_qkv.qweight")
+            == "model.layers.3.linear_attn.in_proj_qkv.qweight"
+        )
+        assert (
+            self._map("blk.3.attn_qkv.qweight_type")
+            == "model.layers.3.linear_attn.in_proj_qkv.qweight_type"
+        )
+
+
+class TestArchCoverage:
+    """A GGUF tensor with no mapper rule is skipped with a warning, and GGUF
+    loading has no completeness check to catch it, so keep the tables in sync
+    with the tensors gguf-py declares for these architectures."""
+
+    # Fused gate_up experts; llama.cpp writes the split form and the HF
+    # checkpoint keeps them separate, so nothing consumes this name.
+    KNOWN_UNMAPPED = {"ffn_gate_up_exps"}
+
+    @pytest.mark.parametrize(
+        ("arch_name", "is_moe"), [("QWEN35", False), ("QWEN35MOE", True)]
+    )
+    def test_every_arch_tensor_has_a_rule(self, arch_name, is_moe):
+        arch = getattr(gguf.MODEL_ARCH, arch_name)
+        mapper = build_qwen35_text_mapper(is_multimodal=False, is_moe=is_moe)
+        base_names = {
+            base for _, base in gguf.get_tensor_name_map(arch, 1).mapping.values()
         }
+        unmapped = sorted(
+            base
+            for base in base_names
+            if base.rsplit(".", 1)[-1] not in self.KNOWN_UNMAPPED
+            # llama.cpp appends the suffix; a tensor is covered if either form maps
+            and all(
+                mapper.apply_list([f"{base}.{suffix}"])[0] == f"{base}.{suffix}"
+                for suffix in ("weight", "bias")
+            )
+        )
+        assert unmapped == []
+
+
+class TestVisionMapper:
+    def _map(self, name):
+        return build_qwen35_vision_mapper().apply_list([name])[0]
+
+    @pytest.mark.parametrize(
+        ("gguf_name", "hf_name"),
+        [
+            ("v.patch_embd.weight", "model.visual.patch_embed.proj.weight"),
+            ("v.position_embd.weight", "model.visual.pos_embed.weight"),
+            ("v.blk.2.attn_qkv.weight", "model.visual.blocks.2.attn.qkv.weight"),
+            ("v.blk.2.attn_out.bias", "model.visual.blocks.2.attn.proj.bias"),
+            ("v.blk.2.ffn_up.weight", "model.visual.blocks.2.mlp.linear_fc1.weight"),
+            ("v.blk.2.ffn_down.bias", "model.visual.blocks.2.mlp.linear_fc2.bias"),
+            ("v.blk.2.ln1.weight", "model.visual.blocks.2.norm1.weight"),
+            ("v.blk.2.ln2.bias", "model.visual.blocks.2.norm2.bias"),
+            # llama.cpp writes merger.norm as v.post_ln and its MLP as mm.N
+            ("mm.0.weight", "model.visual.merger.linear_fc1.weight"),
+            ("mm.2.bias", "model.visual.merger.linear_fc2.bias"),
+            ("v.post_ln.weight", "model.visual.merger.norm.weight"),
+        ],
+    )
+    def test_maps_vision_tensors(self, gguf_name, hf_name):
+        assert self._map(gguf_name) == hf_name
+
+
+class TestSplitStackedExperts:
+    def test_splits_stacked_expert_weight(self):
+        name = "model.layers.0.mlp.experts.0.gate_proj.weight"
+        out = dict(split_stacked_experts([(name, torch.zeros(3, 4, 2))]))
+        assert list(out) == [
+            "model.layers.0.mlp.experts.0.gate_proj.weight",
+            "model.layers.0.mlp.experts.1.gate_proj.weight",
+            "model.layers.0.mlp.experts.2.gate_proj.weight",
+        ]
+        assert all(w.shape == (4, 2) for w in out.values())
+
+    def test_leaves_other_weights_untouched(self):
+        name = "model.layers.0.self_attn.q_proj.weight"
+        out = dict(split_stacked_experts([(name, torch.zeros(4, 2))]))
+        assert list(out) == [name]
+
+
+class TestGdnReorder:
+    def _make_adapter(self, num_key_heads, num_value_heads):
+        config = PretrainedConfig(
+            model_type="qwen3_5",
+            linear_num_key_heads=num_key_heads,
+            linear_num_value_heads=num_value_heads,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+        )
+        adapter = Qwen35GGUFAdapter(config)
+        adapter._set_gdn_reorder()
+        return adapter
+
+    def test_no_reorder_when_value_heads_match_key_heads(self):
+        adapter = self._make_adapter(num_key_heads=4, num_value_heads=4)
+        assert adapter._reorder is None
+        assert "ssm_out.weight" not in adapter._dequant_tensors
+        assert "linear_attn.out_proj" not in adapter._forced_unquantized_modules()
+
+    def test_grouped_value_heads_dequantize_and_unquantize_out_proj(self):
+        # The column reorder needs a float out_proj, so the module must also be
+        # kept out of the GGUF linear method; the two go together.
+        adapter = self._make_adapter(num_key_heads=2, num_value_heads=8)
+        assert adapter._reorder == {
+            "num_k": 2,
+            "r": 4,
+            "head_k": 128,
+            "head_v": 128,
+        }
+        assert "ssm_out.weight" in adapter._dequant_tensors
+        assert "linear_attn.out_proj" in adapter._forced_unquantized_modules()
+
+    def test_always_forces_lm_head_and_embed_tokens(self):
+        adapter = self._make_adapter(num_key_heads=4, num_value_heads=4)
+        assert adapter._forced_unquantized_modules() == ["lm_head", "embed_tokens"]
 
 
 class TestTransformWeights:
     def _transform(self, adapter, weights):
-        return dict(adapter._transform_qwen35_weights(weights))
+        return dict(adapter.transform_weight(weights))
 
     def _make_adapter(self, temporal_patch_size=None):
         config = PretrainedConfig(model_type="qwen3_5")

--- a/tests/test_qwen3_5_adapter.py
+++ b/tests/test_qwen3_5_adapter.py
@@ -26,6 +26,21 @@ class TestMatches:
         assert not Qwen35GGUFAdapter.matches(config)
 
 
+class TestMergerNameMap:
+    def test_maps_merger_tensors(self):
+        name_map = {}
+        Qwen35GGUFAdapter._map_qwen35_merger(name_map)
+        assert name_map == {
+            "mm.0.weight": "model.visual.merger.linear_fc1.weight",
+            "mm.0.bias": "model.visual.merger.linear_fc1.bias",
+            "mm.2.weight": "model.visual.merger.linear_fc2.weight",
+            "mm.2.bias": "model.visual.merger.linear_fc2.bias",
+            # llama.cpp writes merger.norm as v.post_ln, not mm.input_norm
+            "v.post_ln.weight": "model.visual.merger.norm.weight",
+            "v.post_ln.bias": "model.visual.merger.norm.bias",
+        }
+
+
 class TestInferRepoId:
     def test_remote_quant_reference(self):
         model_config = SimpleNamespace(

--- a/tests/test_qwen3_5_adapter.py
+++ b/tests/test_qwen3_5_adapter.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from vllm_gguf_plugin.weights_adapter import get_weights_adapter
+from vllm_gguf_plugin.weights_adapter.qwen3_5 import Qwen35GGUFAdapter
+
+
+class TestMatches:
+    @pytest.mark.parametrize(
+        "model_type",
+        ["qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text"],
+    )
+    def test_matches_qwen35_model_types(self, model_type):
+        config = PretrainedConfig(model_type=model_type)
+        assert Qwen35GGUFAdapter.matches(config)
+        assert isinstance(get_weights_adapter(config), Qwen35GGUFAdapter)
+
+    @pytest.mark.parametrize("model_type", ["qwen3", "qwen3_moe", "gemma3"])
+    def test_does_not_match_other_model_types(self, model_type):
+        config = PretrainedConfig(model_type=model_type)
+        assert not Qwen35GGUFAdapter.matches(config)
+
+
+class TestInferRepoId:
+    def test_remote_quant_reference(self):
+        model_config = SimpleNamespace(
+            model_weights="unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS", model=None
+        )
+        assert (
+            Qwen35GGUFAdapter._infer_repo_id(model_config)
+            == "unsloth/Qwen3.5-0.8B-GGUF"
+        )
+
+    def test_repo_file_reference(self):
+        model_config = SimpleNamespace(
+            model_weights="unsloth/Qwen3.5-0.8B-GGUF/model-Q4_K_M.gguf", model=None
+        )
+        assert (
+            Qwen35GGUFAdapter._infer_repo_id(model_config)
+            == "unsloth/Qwen3.5-0.8B-GGUF"
+        )
+
+    def test_local_file_returns_none(self, tmp_path):
+        gguf_path = tmp_path / "model.gguf"
+        gguf_path.write_bytes(b"GGUF")
+        model_config = SimpleNamespace(model_weights=str(gguf_path), model=None)
+        assert Qwen35GGUFAdapter._infer_repo_id(model_config) is None
+
+    def test_local_dir_with_quant_returns_none(self, tmp_path):
+        model_config = SimpleNamespace(model_weights=f"{tmp_path}:Q8_0", model=None)
+        assert Qwen35GGUFAdapter._infer_repo_id(model_config) is None
+
+
+class TestTransformWeights:
+    def _transform(self, adapter, weights):
+        return dict(adapter._transform_qwen35_weights(weights))
+
+    def _make_adapter(self, temporal_patch_size=None):
+        config = PretrainedConfig(model_type="qwen3_5")
+        if temporal_patch_size is not None:
+            config.vision_config = SimpleNamespace(
+                temporal_patch_size=temporal_patch_size
+            )
+        return Qwen35GGUFAdapter(config)
+
+    def test_skips_quant_params_for_forced_unquantized_modules(self):
+        adapter = self._make_adapter()
+        out = self._transform(
+            adapter,
+            [
+                ("lm_head.qweight", torch.zeros(4, 2)),
+                ("lm_head.qweight_type", torch.tensor(8)),
+                ("model.embed_tokens.qweight", torch.zeros(4, 2)),
+                ("lm_head.weight", torch.zeros(4, 2)),
+            ],
+        )
+        assert list(out) == ["lm_head.weight"]
+
+    def test_expands_conv1d_to_3d(self):
+        adapter = self._make_adapter()
+        name = "model.layers.0.linear_attn.conv1d.weight"
+        out = self._transform(adapter, [(name, torch.zeros(8, 4))])
+        assert out[name].shape == (8, 1, 4)
+
+    def test_restores_output_dim_of_flattened_weight(self):
+        adapter = self._make_adapter()
+        name = "model.layers.0.mlp.shared_expert_gate.weight"
+        out = self._transform(adapter, [(name, torch.zeros(16))])
+        assert out[name].shape == (1, 16)
+
+    def test_keeps_norm_weight_1d(self):
+        adapter = self._make_adapter()
+        name = "model.norm.weight"
+        out = self._transform(adapter, [(name, torch.zeros(16))])
+        assert out[name].shape == (16,)
+
+    def test_expands_patch_embed_temporal_dim(self):
+        adapter = self._make_adapter(temporal_patch_size=2)
+        name = "model.visual.patch_embed.proj.weight"
+        weight = torch.ones(8, 3, 14, 14)
+        out = self._transform(adapter, [(name, weight)])
+        assert out[name].shape == (8, 3, 2, 14, 14)
+        assert torch.allclose(out[name].sum(dim=2), weight)
+
+    def test_keeps_patch_embed_without_temporal_expansion(self):
+        adapter = self._make_adapter(temporal_patch_size=1)
+        name = "model.visual.patch_embed.proj.weight"
+        out = self._transform(adapter, [(name, torch.ones(8, 3, 14, 14))])
+        assert out[name].shape == (8, 3, 14, 14)

--- a/tests/test_qwen3_5_adapter.py
+++ b/tests/test_qwen3_5_adapter.py
@@ -56,6 +56,19 @@ class TestInferRepoId:
         assert Qwen35GGUFAdapter._infer_repo_id(model_config) is None
 
 
+class TestResolveHfCacheDir:
+    def test_hub_cache_layout_returns_cache_root(self, tmp_path):
+        snapshot = (
+            tmp_path / "models--unsloth--Qwen3.5-0.8B-GGUF" / "snapshots" / "abc123"
+        )
+        model_path = snapshot / "model-Q4_K_M.gguf"
+        assert Qwen35GGUFAdapter._resolve_hf_cache_dir(str(model_path)) == str(tmp_path)
+
+    def test_plain_path_returns_none(self, tmp_path):
+        model_path = tmp_path / "gguf" / "model.gguf"
+        assert Qwen35GGUFAdapter._resolve_hf_cache_dir(str(model_path)) is None
+
+
 class TestTransformWeights:
     def _transform(self, adapter, weights):
         return dict(adapter._transform_qwen35_weights(weights))

--- a/tests/test_qwen3_5_adapter.py
+++ b/tests/test_qwen3_5_adapter.py
@@ -41,49 +41,6 @@ class TestMergerNameMap:
         }
 
 
-class TestInferRepoId:
-    def test_remote_quant_reference(self):
-        model_config = SimpleNamespace(
-            model_weights="unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS", model=None
-        )
-        assert (
-            Qwen35GGUFAdapter._infer_repo_id(model_config)
-            == "unsloth/Qwen3.5-0.8B-GGUF"
-        )
-
-    def test_repo_file_reference(self):
-        model_config = SimpleNamespace(
-            model_weights="unsloth/Qwen3.5-0.8B-GGUF/model-Q4_K_M.gguf", model=None
-        )
-        assert (
-            Qwen35GGUFAdapter._infer_repo_id(model_config)
-            == "unsloth/Qwen3.5-0.8B-GGUF"
-        )
-
-    def test_local_file_returns_none(self, tmp_path):
-        gguf_path = tmp_path / "model.gguf"
-        gguf_path.write_bytes(b"GGUF")
-        model_config = SimpleNamespace(model_weights=str(gguf_path), model=None)
-        assert Qwen35GGUFAdapter._infer_repo_id(model_config) is None
-
-    def test_local_dir_with_quant_returns_none(self, tmp_path):
-        model_config = SimpleNamespace(model_weights=f"{tmp_path}:Q8_0", model=None)
-        assert Qwen35GGUFAdapter._infer_repo_id(model_config) is None
-
-
-class TestResolveHfCacheDir:
-    def test_hub_cache_layout_returns_cache_root(self, tmp_path):
-        snapshot = (
-            tmp_path / "models--unsloth--Qwen3.5-0.8B-GGUF" / "snapshots" / "abc123"
-        )
-        model_path = snapshot / "model-Q4_K_M.gguf"
-        assert Qwen35GGUFAdapter._resolve_hf_cache_dir(str(model_path)) == str(tmp_path)
-
-    def test_plain_path_returns_none(self, tmp_path):
-        model_path = tmp_path / "gguf" / "model.gguf"
-        assert Qwen35GGUFAdapter._resolve_hf_cache_dir(str(model_path)) is None
-
-
 class TestTransformWeights:
     def _transform(self, adapter, weights):
         return dict(adapter._transform_qwen35_weights(weights))

--- a/tests/test_qwen3_5_mtp_adapter.py
+++ b/tests/test_qwen3_5_mtp_adapter.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from vllm_gguf_plugin.weights_adapter import get_weights_adapter
+from vllm_gguf_plugin.weights_adapter.qwen3_5_mtp import Qwen35MtpGGUFAdapter
+
+
+class TestMatches:
+    @pytest.mark.parametrize("model_type", ["qwen3_5_mtp", "qwen3_5_moe_mtp"])
+    def test_matches_mtp_model_types(self, model_type):
+        config = PretrainedConfig(model_type=model_type)
+        assert Qwen35MtpGGUFAdapter.matches(config)
+        assert isinstance(get_weights_adapter(config), Qwen35MtpGGUFAdapter)
+
+    @pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+    def test_does_not_match_target_model_types(self, model_type):
+        config = PretrainedConfig(model_type=model_type)
+        assert not Qwen35MtpGGUFAdapter.matches(config)
+
+
+class TestNameMap:
+    def test_maps_block_to_hf_mtp_names(self):
+        name_map = Qwen35MtpGGUFAdapter.build_mtp_name_map(40)
+        assert name_map["blk.40.nextn.eh_proj.weight"] == "mtp.fc.weight"
+        assert (
+            name_map["blk.40.nextn.enorm.weight"] == "mtp.pre_fc_norm_embedding.weight"
+        )
+        assert name_map["blk.40.nextn.shared_head_norm.weight"] == "mtp.norm.weight"
+        assert (
+            name_map["blk.40.attn_norm.weight"] == "mtp.layers.0.input_layernorm.weight"
+        )
+        assert (
+            name_map["blk.40.ffn_gate_inp_shexp.weight"]
+            == "mtp.layers.0.mlp.shared_expert_gate.weight"
+        )
+
+    def test_covers_every_mtp_tensor_once(self):
+        name_map = Qwen35MtpGGUFAdapter.build_mtp_name_map(40)
+        assert len(name_map) == 20
+        assert len(set(name_map.values())) == 20
+        assert all(key.startswith("blk.40.") for key in name_map)
+
+    def test_block_index_is_applied(self):
+        assert set(Qwen35MtpGGUFAdapter.build_mtp_name_map(47)) == {
+            key.replace("blk.40.", "blk.47.")
+            for key in Qwen35MtpGGUFAdapter.build_mtp_name_map(40)
+        }
+
+
+class TestTransformWeights:
+    def _transform(self, weights):
+        return dict(Qwen35MtpGGUFAdapter._transform_mtp_weights(weights))
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "mtp.norm.weight",
+            "mtp.pre_fc_norm_embedding.weight",
+            "mtp.pre_fc_norm_hidden.weight",
+            "mtp.layers.0.input_layernorm.weight",
+            "mtp.layers.0.post_attention_layernorm.weight",
+            "mtp.layers.0.self_attn.q_norm.weight",
+            "mtp.layers.0.self_attn.k_norm.weight",
+        ],
+    )
+    def test_undoes_norm_offset(self, name):
+        out = self._transform([(name, torch.full((8,), 3.0))])
+        assert torch.equal(out[name], torch.full((8,), 2.0))
+
+    def test_restores_shared_expert_gate_output_dim(self):
+        name = "mtp.layers.0.mlp.shared_expert_gate.weight"
+        out = self._transform([(name, torch.zeros(2048))])
+        assert out[name].shape == (1, 2048)
+
+    def test_leaves_quantized_params_untouched(self):
+        weights = [
+            ("mtp.layers.0.self_attn.q_proj.qweight", torch.ones(8, 4)),
+            ("mtp.layers.0.self_attn.q_proj.qweight_type", torch.tensor(14)),
+        ]
+        out = self._transform(weights)
+        assert torch.equal(
+            out["mtp.layers.0.self_attn.q_proj.qweight"], torch.ones(8, 4)
+        )
+        assert out["mtp.layers.0.self_attn.q_proj.qweight_type"] == 14

--- a/tests/test_qwen3_5_mtp_adapter.py
+++ b/tests/test_qwen3_5_mtp_adapter.py
@@ -52,7 +52,7 @@ class TestNameMap:
 
 class TestTransformWeights:
     def _transform(self, weights):
-        return dict(Qwen35MtpGGUFAdapter._transform_mtp_weights(weights))
+        return dict(Qwen35MtpGGUFAdapter.transform_weight(weights))
 
     @pytest.mark.parametrize(
         "name",

--- a/tests/test_qwen3_5_mtp_adapter.py
+++ b/tests/test_qwen3_5_mtp_adapter.py
@@ -5,7 +5,10 @@ import torch
 from transformers import PretrainedConfig
 
 from vllm_gguf_plugin.weights_adapter import get_weights_adapter
-from vllm_gguf_plugin.weights_adapter.qwen3_5_mtp import Qwen35MtpGGUFAdapter
+from vllm_gguf_plugin.weights_adapter.qwen3_5_mtp import (
+    Qwen35MtpGGUFAdapter,
+    build_qwen35_mtp_mapper,
+)
 
 
 class TestMatches:
@@ -21,33 +24,53 @@ class TestMatches:
         assert not Qwen35MtpGGUFAdapter.matches(config)
 
 
-class TestNameMap:
-    def test_maps_block_to_hf_mtp_names(self):
-        name_map = Qwen35MtpGGUFAdapter.build_mtp_name_map(40)
-        assert name_map["blk.40.nextn.eh_proj.weight"] == "mtp.fc.weight"
-        assert (
-            name_map["blk.40.nextn.enorm.weight"] == "mtp.pre_fc_norm_embedding.weight"
-        )
-        assert name_map["blk.40.nextn.shared_head_norm.weight"] == "mtp.norm.weight"
-        assert (
-            name_map["blk.40.attn_norm.weight"] == "mtp.layers.0.input_layernorm.weight"
-        )
-        assert (
-            name_map["blk.40.ffn_gate_inp_shexp.weight"]
-            == "mtp.layers.0.mlp.shared_expert_gate.weight"
-        )
+# HF names of the 20 GGUF tensors an unsloth *-MTP-GGUF keeps in its extra
+# block; these are what the draft's load_weights expects.
+_MOE_BLOCK = {
+    "nextn.eh_proj.weight": "mtp.fc.weight",
+    "nextn.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
+    "nextn.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
+    "nextn.shared_head_norm.weight": "mtp.norm.weight",
+    "attn_norm.weight": "mtp.layers.0.input_layernorm.weight",
+    "post_attention_norm.weight": "mtp.layers.0.post_attention_layernorm.weight",
+    "attn_q.weight": "mtp.layers.0.self_attn.q_proj.weight",
+    "attn_k.weight": "mtp.layers.0.self_attn.k_proj.weight",
+    "attn_v.weight": "mtp.layers.0.self_attn.v_proj.weight",
+    "attn_output.weight": "mtp.layers.0.self_attn.o_proj.weight",
+    "attn_q_norm.weight": "mtp.layers.0.self_attn.q_norm.weight",
+    "attn_k_norm.weight": "mtp.layers.0.self_attn.k_norm.weight",
+    "ffn_gate_inp.weight": "mtp.layers.0.mlp.gate.weight",
+    "ffn_gate_exps.weight": "mtp.layers.0.mlp.experts.0.gate_proj.weight",
+    "ffn_up_exps.weight": "mtp.layers.0.mlp.experts.0.up_proj.weight",
+    "ffn_down_exps.weight": "mtp.layers.0.mlp.experts.0.down_proj.weight",
+    "ffn_gate_shexp.weight": "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+    "ffn_up_shexp.weight": "mtp.layers.0.mlp.shared_expert.up_proj.weight",
+    "ffn_down_shexp.weight": "mtp.layers.0.mlp.shared_expert.down_proj.weight",
+    "ffn_gate_inp_shexp.weight": "mtp.layers.0.mlp.shared_expert_gate.weight",
+}
 
-    def test_covers_every_mtp_tensor_once(self):
-        name_map = Qwen35MtpGGUFAdapter.build_mtp_name_map(40)
-        assert len(name_map) == 20
-        assert len(set(name_map.values())) == 20
-        assert all(key.startswith("blk.40.") for key in name_map)
+
+class TestNameMap:
+    def _map(self, suffixes, block=40, is_moe=True):
+        mapper = build_qwen35_mtp_mapper(block, is_moe=is_moe)
+        return mapper.apply_list([f"blk.{block}.{suffix}" for suffix in suffixes])
+
+    def test_maps_every_moe_block_tensor(self):
+        assert self._map(_MOE_BLOCK) == list(_MOE_BLOCK.values())
 
     def test_block_index_is_applied(self):
-        assert set(Qwen35MtpGGUFAdapter.build_mtp_name_map(47)) == {
-            key.replace("blk.40.", "blk.47.")
-            for key in Qwen35MtpGGUFAdapter.build_mtp_name_map(40)
-        }
+        assert self._map(_MOE_BLOCK, block=47) == list(_MOE_BLOCK.values())
+
+    def test_maps_dense_ffn(self):
+        assert self._map(["ffn_gate.weight", "ffn_up.weight"], is_moe=False) == [
+            "mtp.layers.0.mlp.gate_proj.weight",
+            "mtp.layers.0.mlp.up_proj.weight",
+        ]
+
+    def test_leaves_backbone_blocks_alone(self):
+        mapper = build_qwen35_mtp_mapper(40, is_moe=True)
+        # Other blocks keep their "blk." prefix, so the adapter drops them.
+        assert mapper.apply_list(["blk.39.attn_q.weight"])[0].startswith("blk.39.")
 
 
 class TestTransformWeights:

--- a/tests/test_weight_utils.py
+++ b/tests/test_weight_utils.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+from gguf.quants import GGMLQuantizationType
+
+from vllm_gguf_plugin import weight_utils
+
+
+def _fake_tensor(name: str, tensor_type=GGMLQuantizationType.Q4_0):
+    return SimpleNamespace(
+        name=name,
+        tensor_type=tensor_type,
+        data=np.zeros(4, dtype=np.uint8),
+    )
+
+
+def test_dequant_suffix_matches_whole_path_segments():
+    """``output.weight`` must not drag every ``attn_output.weight`` along: a
+    dequantized tensor for a GGUF-quantized module loads as a plain param the
+    module has no slot for."""
+    reader = SimpleNamespace(
+        byte_order="L",
+        tensors=[
+            _fake_tensor("output.weight"),
+            _fake_tensor("blk.3.attn_output.weight"),
+        ],
+    )
+    with (
+        patch.object(weight_utils.gguf, "GGUFReader", return_value=reader),
+        patch.object(
+            weight_utils.gguf.quants,
+            "dequantize",
+            return_value=np.zeros(4, dtype=np.float32),
+        ),
+    ):
+        names = [
+            name
+            for name, _ in weight_utils.gguf_quant_weights_iterator_multi(
+                ["model.gguf"], dequant_suffixes=("output.weight",)
+            )
+        ]
+
+    assert names == [
+        "output.weight",
+        "blk.3.attn_output.qweight_type",
+        "blk.3.attn_output.qweight",
+    ]

--- a/vllm_gguf_plugin/config_parser.py
+++ b/vllm_gguf_plugin/config_parser.py
@@ -8,6 +8,7 @@ from vllm.transformers_utils.config import HFConfigParser
 from vllm.transformers_utils.config_parser_base import ConfigParserBase
 
 from .gguf_utils import (
+    QWEN35_CONDITIONAL_ARCHS,
     check_gguf_file,
     is_gguf,
     is_remote_gguf,
@@ -39,12 +40,17 @@ class GGUFConfigParser(ConfigParserBase):
             config_dict["norm_topk_prob"] = True
             config.update({"norm_topk_prob": True})
 
-        if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+        if config.model_type in QWEN35_CONDITIONAL_ARCHS:
+            # Qwen3.5 has no ForCausalLM entry in the vLLM model registry —
+            # serve through the ConditionalGeneration architecture instead.
+            architecture = QWEN35_CONDITIONAL_ARCHS[config.model_type]
+        elif config.model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+            architecture = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
+        else:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
 
-        model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
-        config_dict["architectures"] = [model_type]
-        config.update({"architectures": [model_type]})
+        config_dict["architectures"] = [architecture]
+        config.update({"architectures": [architecture]})
 
         if is_gguf(original_model):
             config = maybe_patch_hf_config_from_gguf(str(original_model), config)

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -16,6 +16,14 @@ from vllm.transformers_utils.repo_utils import list_filtered_repo_files
 
 logger = init_logger(__name__)
 
+# Qwen3.5 has no ForCausalLM entry in the vLLM model registry.
+QWEN35_CONDITIONAL_ARCHS = {
+    "qwen3_5": "Qwen3_5ForConditionalGeneration",
+    "qwen3_5_text": "Qwen3_5ForConditionalGeneration",
+    "qwen3_5_moe": "Qwen3_5MoeForConditionalGeneration",
+    "qwen3_5_moe_text": "Qwen3_5MoeForConditionalGeneration",
+}
+
 
 @cache
 def check_gguf_file(model: str | PathLike) -> bool:
@@ -352,6 +360,33 @@ def maybe_patch_hf_config_from_gguf(
             if vocab_size is not None:
                 new_hf_config.text_config.update({"vocab_size": vocab_size})
             hf_config = new_hf_config
+
+        # Qwen3.5: upgrade text-only config to multimodal when mmproj found
+        if getattr(hf_config, "vision_config", None) is None:
+            if hf_config.model_type in ("qwen3_5", "qwen3_5_text"):
+                from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5Config
+
+                hf_config = Qwen3_5Config(
+                    text_config=hf_config.to_dict(),
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                )
+            elif hf_config.model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
+                from vllm.transformers_utils.configs.qwen3_5_moe import (
+                    Qwen3_5MoeConfig,
+                )
+
+                hf_config = Qwen3_5MoeConfig(
+                    text_config=hf_config.to_dict(),
+                    architectures=["Qwen3_5MoeForConditionalGeneration"],
+                )
+
+    # Qwen3.5 has no ForCausalLM entry in the vLLM model registry — always
+    # serve through the ConditionalGeneration architecture.
+    conditional_arch = QWEN35_CONDITIONAL_ARCHS.get(hf_config.model_type)
+    if conditional_arch is not None:
+        archs = getattr(hf_config, "architectures", None) or []
+        if not any("ConditionalGeneration" in arch for arch in archs):
+            hf_config.architectures = [conditional_arch]
 
     return hf_config
 

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -391,6 +391,17 @@ def maybe_patch_hf_config_from_gguf(
     return hf_config
 
 
+def find_nextn_block_index(gguf_files: list[str]) -> int | None:
+    """Return the block index of the MTP/nextn layer in *gguf_files*, or None
+    when the export dropped it (llama.cpp skips ``mtp.*`` by default; unsloth's
+    ``*-MTP-GGUF`` repos keep it as one extra block)."""
+    for gguf_file in gguf_files:
+        for tensor in gguf.GGUFReader(gguf_file).tensors:
+            if match := re.match(r"blk\.(\d+)\.nextn\.", tensor.name):
+                return int(match.group(1))
+    return None
+
+
 def get_gguf_file_path_from_hf(
     repo_id: str | Path,
     quant_type: str,

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -18,8 +18,13 @@ from vllm.utils.torch_utils import set_default_torch_dtype
 
 from .gguf_utils import find_nextn_block_index
 from .quantization import GGUFConfig
-from .weight_utils import download_gguf, download_mmproj, resolve_local_gguf
-from .weights_adapter import GGUFWeightsAdapter, get_weights_adapter
+from .weight_utils import (
+    download_gguf,
+    download_mmproj,
+    get_gguf_shard_files,
+    resolve_local_gguf,
+)
+from .weights_adapter import get_weights_adapter
 
 logger = init_logger(__name__)
 
@@ -125,7 +130,7 @@ class GGUFModelLoader(BaseModelLoader):
 
     def _gguf_has_mtp(self, target_mc: ModelConfig) -> bool:
         """Whether the target's GGUF carries the MTP/nextn draft block."""
-        files = GGUFWeightsAdapter._get_all_gguf_files(self._prepare_weights(target_mc))
+        files = get_gguf_shard_files(self._prepare_weights(target_mc))
         return find_nextn_block_index(files) is not None
 
     def _load_hf_draft(

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -48,16 +48,13 @@ class GGUFModelLoader(BaseModelLoader):
         model_name_or_path = model_config.model_weights or model_config.model
         if os.path.isfile(model_name_or_path):
             return model_name_or_path
-        # Multimodal configs need the projector next to the backbone.
-        hf_config = model_config.hf_config
-        needs_mmproj = getattr(hf_config, "vision_config", None) is not None
         # local_dir:quant_type (e.g. /path/to/gguf-dir:Q8_0)
         if ":" in model_name_or_path:
             local_dir, quant_type = model_name_or_path.rsplit(":", 1)
             if os.path.isdir(local_dir):
                 return resolve_local_gguf(local_dir, quant_type)
             # remote repo_id:quant_type
-            if needs_mmproj:
+            if getattr(model_config.hf_config, "vision_config", None) is not None:
                 download_mmproj(
                     local_dir,
                     cache_dir=self.load_config.download_dir,
@@ -73,12 +70,7 @@ class GGUFModelLoader(BaseModelLoader):
         # repo id/filename.gguf
         if "/" in model_name_or_path and model_name_or_path.endswith(".gguf"):
             repo_id, filename = model_name_or_path.rsplit("/", 1)
-            if needs_mmproj:
-                download_mmproj(repo_id, revision=model_config.revision)
-            # Same revision as the mmproj, or they land in different snapshots.
-            return hf_hub_download(
-                repo_id=repo_id, filename=filename, revision=model_config.revision
-            )
+            return hf_hub_download(repo_id=repo_id, filename=filename)
 
         raise ValueError(
             f"Unrecognised GGUF reference: {model_name_or_path} "

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -16,9 +16,10 @@ from vllm.model_executor.model_loader.utils import (
 )
 from vllm.utils.torch_utils import set_default_torch_dtype
 
+from .gguf_utils import find_nextn_block_index
 from .quantization import GGUFConfig
 from .weight_utils import download_gguf, resolve_local_gguf
-from .weights_adapter import get_weights_adapter
+from .weights_adapter import GGUFWeightsAdapter, get_weights_adapter
 
 logger = init_logger(__name__)
 
@@ -108,6 +109,11 @@ class GGUFModelLoader(BaseModelLoader):
             hf_hub_download(repo, shard, revision=model_config.revision)
         return os.path.dirname(index_path)
 
+    def _gguf_has_mtp(self, target_mc: ModelConfig) -> bool:
+        """Whether the target's GGUF carries the MTP/nextn draft block."""
+        files = GGUFWeightsAdapter._get_all_gguf_files(self._prepare_weights(target_mc))
+        return find_nextn_block_index(files) is not None
+
     def _load_hf_draft(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str
     ) -> nn.Module:
@@ -146,17 +152,16 @@ class GGUFModelLoader(BaseModelLoader):
         device_config = vllm_config.device_config
         # A draft ModelConfig has no GGUF reference of its own.
         target_mc = vllm_config.model_config
-        if model_config is not target_mc and not model_config.model_weights:
+        is_draft = model_config is not target_mc
+        if is_draft and not model_config.model_weights:
             model_type = getattr(model_config.hf_config, "model_type", "") or ""
-            # llama.cpp/unsloth GGUF exports omit the MTP/nextn draft layers,
-            # but they exist in the HF safetensors repo. Load the draft from
-            # there in native dtype instead of the GGUF loader.
-            if "mtp" in model_type:
+            # Only unsloth's *-MTP-GGUF keeps the nextn block.
+            if "mtp" in model_type and not self._gguf_has_mtp(target_mc):
                 return self._load_hf_draft(vllm_config, model_config, prefix)
-            # Otherwise the draft shares the target's GGUF file — borrow its ref.
             model_config.model_weights = target_mc.model_weights
         adapter = self._prepare_adapter(model_config)
-        vllm_config.model_config.hf_config = model_config.hf_config
+        if not is_draft:
+            vllm_config.model_config.hf_config = model_config.hf_config
         logger.debug(
             "GGUF unquantized modules: %s", adapter.load_spec.unquantized_modules
         )

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -173,7 +173,12 @@ class GGUFModelLoader(BaseModelLoader):
         target_device = torch.device(device_config.device)
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
-                model = initialize_model(vllm_config=vllm_config, prefix=prefix)
+                # vllm_config.model_config stays the target's even for a draft.
+                model = initialize_model(
+                    vllm_config=vllm_config,
+                    model_config=model_config,
+                    prefix=prefix,
+                )
             model.load_weights(
                 adapter.prepare_weights(model_config),
             )

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -79,6 +79,31 @@ class GGUFModelLoader(BaseModelLoader):
         adapter = self._prepare_adapter(model_config)
         model.load_weights(adapter.prepare_weights(model_config))
 
+    @staticmethod
+    def _prefetch_mtp_weights(model_config: ModelConfig) -> str | None:
+        """Fetch only the ``mtp.*`` safetensors shards into the HF cache,
+        avoiding the full (tens of GiB) checkpoint. Returns the snapshot dir,
+        or None to let the default loader download normally."""
+        import json
+
+        repo = str(model_config.model)
+        if os.path.isdir(repo):
+            return None
+        try:
+            index_path = hf_hub_download(
+                repo, "model.safetensors.index.json", revision=model_config.revision
+            )
+        except Exception:
+            return None  # single-file checkpoint or no index — fall back
+        weight_map = json.load(open(index_path))["weight_map"]
+        shards = sorted({f for name, f in weight_map.items() if "mtp" in name.lower()})
+        if not shards:
+            return None
+        logger.info("Prefetching %d MTP shard(s): %s", len(shards), shards)
+        for shard in shards:
+            hf_hub_download(repo, shard, revision=model_config.revision)
+        return os.path.dirname(index_path)
+
     def _load_hf_draft(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str
     ) -> nn.Module:
@@ -93,9 +118,14 @@ class GGUFModelLoader(BaseModelLoader):
         )
         saved_quant_config = vllm_config.quant_config
         saved_quantization = model_config.quantization
+        saved_model = model_config.model
         vllm_config.quant_config = None
         model_config.quantization = None
         model_config.model_weights = None  # use model_config.model (HF repo)
+        # Point the loader at a snapshot with only the MTP shards when possible.
+        mtp_dir = self._prefetch_mtp_weights(model_config)
+        if mtp_dir is not None:
+            model_config.model = mtp_dir
         try:
             loader = get_model_loader(LoadConfig(load_format="auto"))
             return loader.load_model(
@@ -104,6 +134,7 @@ class GGUFModelLoader(BaseModelLoader):
         finally:
             vllm_config.quant_config = saved_quant_config
             model_config.quantization = saved_quantization
+            model_config.model = saved_model
 
     def load_model(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -93,9 +93,13 @@ class GGUFModelLoader(BaseModelLoader):
             index_path = hf_hub_download(
                 repo, "model.safetensors.index.json", revision=model_config.revision
             )
-        except Exception:
-            return None  # single-file checkpoint or no index — fall back
-        weight_map = json.load(open(index_path))["weight_map"]
+        except Exception as e:
+            # No index (single-file checkpoint), or the fetch failed — the
+            # caller then downloads the whole repo, so say why.
+            logger.info("No MTP shard index for %s (%s)", repo, e)
+            return None
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
         shards = sorted({f for name, f in weight_map.items() if "mtp" in name.lower()})
         if not shards:
             return None

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -79,10 +79,47 @@ class GGUFModelLoader(BaseModelLoader):
         adapter = self._prepare_adapter(model_config)
         model.load_weights(adapter.prepare_weights(model_config))
 
+    def _load_hf_draft(
+        self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str
+    ) -> nn.Module:
+        """Load an MTP draft from the HF safetensors repo in native dtype,
+        clearing GGUF quantization for this load only."""
+        from vllm.model_executor.model_loader import get_model_loader
+
+        logger.info(
+            "Loading speculative draft '%s' from HF repo %s (not in GGUF)",
+            getattr(model_config.hf_config, "model_type", "?"),
+            model_config.model,
+        )
+        saved_quant_config = vllm_config.quant_config
+        saved_quantization = model_config.quantization
+        vllm_config.quant_config = None
+        model_config.quantization = None
+        model_config.model_weights = None  # use model_config.model (HF repo)
+        try:
+            loader = get_model_loader(LoadConfig(load_format="auto"))
+            return loader.load_model(
+                vllm_config=vllm_config, model_config=model_config, prefix=prefix
+            )
+        finally:
+            vllm_config.quant_config = saved_quant_config
+            model_config.quantization = saved_quantization
+
     def load_model(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""
     ) -> nn.Module:
         device_config = vllm_config.device_config
+        # A draft ModelConfig has no GGUF reference of its own.
+        target_mc = vllm_config.model_config
+        if model_config is not target_mc and not model_config.model_weights:
+            model_type = getattr(model_config.hf_config, "model_type", "") or ""
+            # llama.cpp/unsloth GGUF exports omit the MTP/nextn draft layers,
+            # but they exist in the HF safetensors repo. Load the draft from
+            # there in native dtype instead of the GGUF loader.
+            if "mtp" in model_type:
+                return self._load_hf_draft(vllm_config, model_config, prefix)
+            # Otherwise the draft shares the target's GGUF file — borrow its ref.
+            model_config.model_weights = target_mc.model_weights
         adapter = self._prepare_adapter(model_config)
         vllm_config.model_config.hf_config = model_config.hf_config
         logger.debug(

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -18,7 +18,7 @@ from vllm.utils.torch_utils import set_default_torch_dtype
 
 from .gguf_utils import find_nextn_block_index
 from .quantization import GGUFConfig
-from .weight_utils import download_gguf, resolve_local_gguf
+from .weight_utils import download_gguf, download_mmproj, resolve_local_gguf
 from .weights_adapter import GGUFWeightsAdapter, get_weights_adapter
 
 logger = init_logger(__name__)
@@ -43,12 +43,21 @@ class GGUFModelLoader(BaseModelLoader):
         model_name_or_path = model_config.model_weights or model_config.model
         if os.path.isfile(model_name_or_path):
             return model_name_or_path
+        # Multimodal configs need the projector next to the backbone.
+        hf_config = model_config.hf_config
+        needs_mmproj = getattr(hf_config, "vision_config", None) is not None
         # local_dir:quant_type (e.g. /path/to/gguf-dir:Q8_0)
         if ":" in model_name_or_path:
             local_dir, quant_type = model_name_or_path.rsplit(":", 1)
             if os.path.isdir(local_dir):
                 return resolve_local_gguf(local_dir, quant_type)
             # remote repo_id:quant_type
+            if needs_mmproj:
+                download_mmproj(
+                    local_dir,
+                    cache_dir=self.load_config.download_dir,
+                    revision=model_config.revision,
+                )
             return download_gguf(
                 local_dir,
                 quant_type,
@@ -59,7 +68,12 @@ class GGUFModelLoader(BaseModelLoader):
         # repo id/filename.gguf
         if "/" in model_name_or_path and model_name_or_path.endswith(".gguf"):
             repo_id, filename = model_name_or_path.rsplit("/", 1)
-            return hf_hub_download(repo_id=repo_id, filename=filename)
+            if needs_mmproj:
+                download_mmproj(repo_id, revision=model_config.revision)
+            # Same revision as the mmproj, or they land in different snapshots.
+            return hf_hub_download(
+                repo_id=repo_id, filename=filename, revision=model_config.revision
+            )
 
         raise ValueError(
             f"Unrecognised GGUF reference: {model_name_or_path} "

--- a/vllm_gguf_plugin/quantization/params.py
+++ b/vllm_gguf_plugin/quantization/params.py
@@ -42,6 +42,12 @@ def _resolve_gguf_weight_type_loader(
         if loaded_shard_id is None and hasattr(param, "_store"):
             param._store(loaded_weight)
             return
+        if isinstance(loaded_shard_id, tuple) and hasattr(param, "_store"):
+            # Fused weight type covers multiple shards (e.g. Qwen3.5 GDN
+            # in_proj_qkv loading into in_proj_qkvz shards (0, 1, 2)).
+            for shard_id in loaded_shard_id:
+                param._store(loaded_weight, shard_id=shard_id)
+            return
         base_loader(param, loaded_weight, loaded_shard_id)
 
     return _gguf_weight_type_loader_v2

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -120,6 +120,15 @@ def gguf_quant_weights_iterator_multi(
                 name = tensor.name
 
             weight_type = tensor.tensor_type
+            # embed_tokens / lm_head load into VocabParallelEmbedding /
+            # ParallelLMHead as plain weights; dequantize instead of emitting
+            # GGUF quant params (which those layers drop, leaving zeros).
+            if weight_type.name not in _QUANT_TYPES and name.endswith(
+                ("embed_tokens.weight", "lm_head.weight")
+            ):
+                deq = gguf.quants.dequantize(tensor.data, weight_type)
+                yield name, torch.tensor(deq)
+                continue
             if weight_type.name not in _QUANT_TYPES:
                 yield name.replace("weight", "qweight_type"), torch.tensor(weight_type)
                 name = name.replace("weight", "qweight")

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -80,6 +80,15 @@ def get_gguf_extra_tensor_names(
     return [gguf_to_hf_name_map[key] for key in extra_keys]
 
 
+def get_gguf_tensor_names(gguf_files: list[str]) -> set[str]:
+    """Names of every tensor in *gguf_files*, regardless of any name map."""
+    return {
+        tensor.name
+        for gguf_file in gguf_files
+        for tensor in gguf.GGUFReader(gguf_file).tensors
+    }
+
+
 def get_gguf_weight_type_map(
     gguf_file: str | Path, gguf_to_hf_name_map: dict[str, str]
 ) -> dict[str, str]:

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -184,8 +184,12 @@ def gguf_quant_weights_iterator_multi(
 
             weight_type = tensor.tensor_type
             # These load as plain weights; emitting GGUF quant params here
-            # would leave them zeroed.
-            if weight_type.name not in _QUANT_TYPES and name.endswith(dequant_suffixes):
+            # would leave them zeroed. Match on whole path segments, or
+            # "output.weight" would also catch every "attn_output.weight".
+            if weight_type.name not in _QUANT_TYPES and any(
+                name == suffix or name.endswith(f".{suffix}")
+                for suffix in dequant_suffixes
+            ):
                 deq = gguf.quants.dequantize(tensor.data, weight_type)
                 yield name, torch.tensor(deq)
                 continue

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -98,7 +98,9 @@ def gguf_quant_weights_iterator(
 
 
 def gguf_quant_weights_iterator_multi(
-    gguf_files: list[str], gguf_to_hf_name_map: dict[str, str] | None = None
+    gguf_files: list[str],
+    gguf_to_hf_name_map: dict[str, str] | None = None,
+    dequant_suffixes: tuple[str, ...] = ("embed_tokens.weight", "lm_head.weight"),
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Yield ``(name, tensor)`` for all tensors in *gguf_files*.
 
@@ -124,7 +126,7 @@ def gguf_quant_weights_iterator_multi(
             # ParallelLMHead as plain weights; dequantize instead of emitting
             # GGUF quant params (which those layers drop, leaving zeros).
             if weight_type.name not in _QUANT_TYPES and name.endswith(
-                ("embed_tokens.weight", "lm_head.weight")
+                dequant_suffixes
             ):
                 deq = gguf.quants.dequantize(tensor.data, weight_type)
                 yield name, torch.tensor(deq)

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -60,11 +60,9 @@ def download_mmproj(
 ) -> None:
     """Fetch the multimodal projector into the backbone's snapshot dir.
 
-    ``download_gguf`` only matches the requested quant type, so the mmproj
-    file of a multimodal repo is never pulled by it. Repos ship the projector
-    in several precisions; take one, both to save the download and to keep
-    ``detect_gguf_multimodal`` deterministic. Downloading through the hub
-    cache keeps concurrent TP workers serialized on the cache lock.
+    ``download_gguf`` only matches the requested quant type, so it never pulls
+    the mmproj file. Repos ship the projector in several precisions; take one
+    so ``detect_gguf_multimodal`` stays deterministic.
     """
     try:
         mmproj_files = list_filtered_repo_files(

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -9,8 +9,9 @@ from pathlib import Path
 import gguf
 import numpy as np
 import torch
-from huggingface_hub import snapshot_download
+from huggingface_hub import hf_hub_download, snapshot_download
 from vllm.logger import init_logger
+from vllm.transformers_utils.repo_utils import list_filtered_repo_files
 
 logger = init_logger(__name__)
 
@@ -49,6 +50,37 @@ def download_gguf(
 
     local_files.sort(key=lambda x: (x.count("-"), x))
     return local_files[0]
+
+
+def download_mmproj(
+    repo_id: str,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+) -> None:
+    """Fetch the multimodal projector into the backbone's snapshot dir.
+
+    ``download_gguf`` only matches the requested quant type, so the mmproj
+    file of a multimodal repo is never pulled by it. Repos ship the projector
+    in several precisions; take one, both to save the download and to keep
+    ``detect_gguf_multimodal`` deterministic. Downloading through the hub
+    cache keeps concurrent TP workers serialized on the cache lock.
+    """
+    try:
+        mmproj_files = list_filtered_repo_files(
+            repo_id, allow_patterns=["*mmproj*.gguf"], revision=revision
+        )
+        if not mmproj_files:
+            return
+        filename = sorted(mmproj_files)[0]
+        logger.info("Downloading mmproj file %s from %s", filename, repo_id)
+        hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            cache_dir=cache_dir,
+            revision=revision,
+        )
+    except Exception as e:
+        logger.warning("Failed to download mmproj from %s: %s", repo_id, e)
 
 
 def resolve_local_gguf(local_dir: str, quant_type: str) -> str:

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -3,7 +3,8 @@
 import glob
 import itertools
 import os
-from collections.abc import Generator
+import re
+from collections.abc import Generator, Iterable
 from pathlib import Path
 
 import gguf
@@ -102,6 +103,25 @@ def resolve_local_gguf(local_dir: str, quant_type: str) -> str:
     return matches[0]
 
 
+def get_gguf_shard_files(model_path: str) -> list[str]:
+    """All shards of a split GGUF, or just *model_path* when it is whole."""
+    match = re.search(r"-(\d+)-of-(\d+)\.gguf$", model_path)
+    if not match:
+        return [model_path]
+    total = int(match.group(2))
+    num_digits = len(match.group(1))
+    prefix = model_path[: match.start(1)]
+    suffix = model_path[match.end(2) :]
+    files = []
+    for i in range(1, total + 1):
+        shard_path = f"{prefix}{i:0{num_digits}d}-of-{total:0{num_digits}d}{suffix}"
+        if os.path.isfile(shard_path):
+            files.append(shard_path)
+    if files:
+        logger.info("Discovered %d GGUF shard files", len(files))
+    return files if files else [model_path]
+
+
 def get_gguf_extra_tensor_names(
     gguf_file: str | Path, gguf_to_hf_name_map: dict[str, str]
 ) -> list[str]:
@@ -182,6 +202,20 @@ def gguf_quant_weights_iterator_multi(
             else:
                 param = torch.tensor(weight)
             yield name, param
+
+
+def split_stacked_experts(
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Split a stacked GGUF expert tensor into the per-expert weights vLLM
+    loads, leaving every other weight untouched."""
+    for name, weight in weights:
+        if weight.ndim == 3 and ".experts.0." in name:
+            for expert_id, expert_weight in enumerate(weight.unbind()):
+                expert_name = name.replace(".experts.0.", f".experts.{expert_id}.")
+                yield expert_name, expert_weight
+        else:
+            yield name, weight
 
 
 def get_gguf_unquantized_params(gguf_files: list[str]) -> list[str]:

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -122,12 +122,9 @@ def gguf_quant_weights_iterator_multi(
                 name = tensor.name
 
             weight_type = tensor.tensor_type
-            # embed_tokens / lm_head load into VocabParallelEmbedding /
-            # ParallelLMHead as plain weights; dequantize instead of emitting
-            # GGUF quant params (which those layers drop, leaving zeros).
-            if weight_type.name not in _QUANT_TYPES and name.endswith(
-                dequant_suffixes
-            ):
+            # These load as plain weights; emitting GGUF quant params here
+            # would leave them zeroed.
+            if weight_type.name not in _QUANT_TYPES and name.endswith(dequant_suffixes):
                 deq = gguf.quants.dequantize(tensor.data, weight_type)
                 yield name, torch.tensor(deq)
                 continue

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -14,14 +14,14 @@ from .gemma3 import Gemma3GGUFAdapter
 from .qwen3_5 import Qwen35GGUFAdapter
 from .qwen3_5_mtp import Qwen35MtpGGUFAdapter
 
-_ADAPTER_REGISTRY: list[type[GGUFWeightsAdapter]] = [
+_ADAPTER_REGISTRY: list[type[BaseGGUFWeightsAdapter]] = [
     Gemma3GGUFAdapter,
     Qwen35GGUFAdapter,
     Qwen35MtpGGUFAdapter,
 ]
 
 
-def get_weights_adapter(config) -> GGUFWeightsAdapter:
+def get_weights_adapter(config) -> BaseGGUFWeightsAdapter:
     """Return the adapter for *config*, falling back to the default."""
     for cls in _ADAPTER_REGISTRY:
         if cls.matches(config):

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -11,9 +11,11 @@ from .diffusion import (
     get_diffusion_gguf_adapter,
 )
 from .gemma3 import Gemma3GGUFAdapter
+from .qwen3_5 import Qwen35GGUFAdapter
 
 _ADAPTER_REGISTRY: list[type[GGUFWeightsAdapter]] = [
     Gemma3GGUFAdapter,
+    Qwen35GGUFAdapter,
 ]
 
 

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -12,10 +12,12 @@ from .diffusion import (
 )
 from .gemma3 import Gemma3GGUFAdapter
 from .qwen3_5 import Qwen35GGUFAdapter
+from .qwen3_5_mtp import Qwen35MtpGGUFAdapter
 
 _ADAPTER_REGISTRY: list[type[GGUFWeightsAdapter]] = [
     Gemma3GGUFAdapter,
     Qwen35GGUFAdapter,
+    Qwen35MtpGGUFAdapter,
 ]
 
 
@@ -33,6 +35,8 @@ __all__ = [
     "Flux2KleinDiffusionGGUFAdapter",
     "GGUFWeightsAdapter",
     "Gemma3GGUFAdapter",
+    "Qwen35GGUFAdapter",
+    "Qwen35MtpGGUFAdapter",
     "QwenImageDiffusionGGUFAdapter",
     "ZImageDiffusionGGUFAdapter",
     "get_diffusion_gguf_adapter",

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -75,7 +75,11 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                     f"model.visual.merger.{hf_name}.{suffix}"
                 )
 
-    def build_name_map(self, model_config: ModelConfig) -> dict[str, str]:
+    def build_name_map(
+        self,
+        model_config: ModelConfig,
+        gguf_tensor_names: set[str] | None = None,
+    ) -> dict[str, str]:
         config = model_config.hf_config
         text_config = config.get_text_config()
         model_type = config.model_type
@@ -182,11 +186,18 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
                     f"{layer_prefix}.{idx}.mlp.experts.0.up_proj.weight"
                 )
-                sideload_params.append(
-                    regex.compile(
-                        f"{layer_prefix_re}\\.{idx}"
-                        r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
-                    )
+                sideload_params.extend(
+                    [
+                        regex.compile(
+                            f"{layer_prefix_re}\\.{idx}"
+                            r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
+                        ),
+                        # Fused expert params; loaded via the per-expert names.
+                        regex.compile(
+                            f"{layer_prefix_re}\\.{idx}"
+                            r"\.mlp\.experts\.(gate_up_proj|down_proj)"
+                        ),
+                    ]
                 )
         if model_type == "minimax_m2":
             model_type = "minimax-m2"
@@ -305,6 +316,19 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 f"Failed to map GGUF parameters "
                 f"({len(unmapped_params)}): {unmapped_params}"
             )
+        # The mirror of the check above: a name mapped to a tensor no file has
+        # would load at its random init. Sideloaded params are the exceptions.
+        if gguf_tensor_names is not None:
+            missing = sorted(
+                hf_name
+                for gguf_name, hf_name in gguf_to_hf_name_map.items()
+                if gguf_name not in gguf_tensor_names
+                and not any(regex.fullmatch(p, hf_name) for p in sideload_params)
+            )
+            if missing:
+                logger.warning(
+                    "No GGUF tensor for %d mapped param(s): %s", len(missing), missing
+                )
         return gguf_to_hf_name_map
 
     def map_weights(

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import gguf
 import regex
 import torch
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 from vllm.logger import init_logger
 
 from ..gguf_utils import maybe_patch_hf_config_from_gguf
@@ -119,6 +119,77 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                         ),
                     ]
                 )
+        if model_type in ("qwen3_5", "qwen3_5_text"):
+            model_type = "qwen35"
+            # dt_bias may not exist in GGUF (can be folded into dt_proj)
+            sideload_params.append(
+                regex.compile(
+                    r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
+                )
+            )
+            if is_multimodal:
+                # Manual GGUF→HF mappings for the Qwen3.5 merger (mmproj);
+                # gguf-py's MMPROJ map has no linear_fc1/fc2 patterns
+                gguf_to_hf_name_map["mm.0.weight"] = (
+                    "model.visual.merger.linear_fc1.weight"
+                )
+                gguf_to_hf_name_map["mm.0.bias"] = "model.visual.merger.linear_fc1.bias"
+                gguf_to_hf_name_map["mm.2.weight"] = (
+                    "model.visual.merger.linear_fc2.weight"
+                )
+                gguf_to_hf_name_map["mm.2.bias"] = "model.visual.merger.linear_fc2.bias"
+                gguf_to_hf_name_map["mm.input_norm.weight"] = (
+                    "model.visual.merger.norm.weight"
+                )
+                gguf_to_hf_name_map["mm.input_norm.bias"] = (
+                    "model.visual.merger.norm.bias"
+                )
+        if model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
+            model_type = "qwen35moe"
+            # dt_bias may not exist in GGUF (can be folded into dt_proj)
+            sideload_params.append(
+                regex.compile(
+                    r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
+                )
+            )
+            if is_multimodal:
+                # Same merger mappings for the MoE variant
+                gguf_to_hf_name_map["mm.0.weight"] = (
+                    "model.visual.merger.linear_fc1.weight"
+                )
+                gguf_to_hf_name_map["mm.0.bias"] = "model.visual.merger.linear_fc1.bias"
+                gguf_to_hf_name_map["mm.2.weight"] = (
+                    "model.visual.merger.linear_fc2.weight"
+                )
+                gguf_to_hf_name_map["mm.2.bias"] = "model.visual.merger.linear_fc2.bias"
+                gguf_to_hf_name_map["mm.input_norm.weight"] = (
+                    "model.visual.merger.norm.weight"
+                )
+                gguf_to_hf_name_map["mm.input_norm.bias"] = (
+                    "model.visual.merger.norm.bias"
+                )
+            # GGUF layer map assumes merged expert weights.
+            # Multimodal uses the model.language_model.layers prefix.
+            layer_prefix = (
+                "model.language_model.layers" if is_multimodal else "model.layers"
+            )
+            layer_prefix_re = layer_prefix.replace(".", "\\.")
+            for idx in range(text_config.num_hidden_layers):
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
+                    f"{layer_prefix}.{idx}.mlp.experts.0.down_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
+                    f"{layer_prefix}.{idx}.mlp.experts.0.gate_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
+                    f"{layer_prefix}.{idx}.mlp.experts.0.up_proj.weight"
+                )
+                sideload_params.append(
+                    regex.compile(
+                        f"{layer_prefix_re}\\.{idx}"
+                        r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
+                    )
+                )
         if model_type == "minimax_m2":
             model_type = "minimax-m2"
             for idx in range(config.num_hidden_layers):
@@ -153,14 +224,22 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
 
         if is_multimodal:
             mm_proj_arch = gguf.MODEL_ARCH.MMPROJ
-            vision_name_map = gguf.get_tensor_name_map(
-                mm_proj_arch, config.vision_config.num_hidden_layers
+            # Some vision configs use 'depth' instead of 'num_hidden_layers'
+            # (e.g. Qwen3_5VisionConfig)
+            vision_num_layers = getattr(
+                config.vision_config,
+                "num_hidden_layers",
+                getattr(config.vision_config, "depth", 0),
             )
+            vision_name_map = gguf.get_tensor_name_map(mm_proj_arch, vision_num_layers)
         else:
             vision_name_map = None
 
+        auto_cls = (
+            AutoModelForImageTextToText if is_multimodal else AutoModelForCausalLM
+        )
         with torch.device("meta"):
-            dummy_model = AutoModelForCausalLM.from_config(
+            dummy_model = auto_cls.from_config(
                 config, trust_remote_code=model_config.trust_remote_code
             )
 

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -43,43 +43,9 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
     def patch_hf_config(self, model_path: str, hf_config: PretrainedConfig):
         return maybe_patch_hf_config_from_gguf(model_path, hf_config)
 
-    @staticmethod
-    def _map_gdn_dt_bias(
-        gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
-    ):
-        # gguf-py has no map for dt_bias; without this it stays zero and
-        # breaks GDN recurrence. sideload is the fallback when GGUF omits it.
-        layer_prefix = (
-            "model.language_model.layers" if is_multimodal else "model.layers"
-        )
-        for idx in range(text_config.num_hidden_layers):
-            gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.bias"] = (
-                f"{layer_prefix}.{idx}.linear_attn.dt_bias"
-            )
-        sideload_params.append(
-            regex.compile(
-                r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
-            )
-        )
-
-    @staticmethod
-    def _map_qwen35_merger(gguf_to_hf_name_map):
-        # gguf-py's MMPROJ map has no linear_fc1/fc2 patterns, and llama.cpp
-        # writes the merger norm as v.post_ln.
-        for gguf_name, hf_name in (
-            ("mm.0", "linear_fc1"),
-            ("mm.2", "linear_fc2"),
-            ("v.post_ln", "norm"),
-        ):
-            for suffix in ("weight", "bias"):
-                gguf_to_hf_name_map[f"{gguf_name}.{suffix}"] = (
-                    f"model.visual.merger.{hf_name}.{suffix}"
-                )
-
     def build_name_map(
         self,
         model_config: ModelConfig,
-        gguf_tensor_names: set[str] | None = None,
     ) -> dict[str, str]:
         config = model_config.hf_config
         text_config = config.get_text_config()
@@ -153,49 +119,6 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                         ),
                         regex.compile(
                             f"model\\.layers\\.{idx}"
-                            r"\.mlp\.experts\.(gate_up_proj|down_proj)"
-                        ),
-                    ]
-                )
-        if model_type in ("qwen3_5", "qwen3_5_text"):
-            model_type = "qwen35"
-            self._map_gdn_dt_bias(
-                gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
-            )
-            if is_multimodal:
-                self._map_qwen35_merger(gguf_to_hf_name_map)
-        if model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
-            model_type = "qwen35moe"
-            self._map_gdn_dt_bias(
-                gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
-            )
-            if is_multimodal:
-                self._map_qwen35_merger(gguf_to_hf_name_map)
-            # GGUF layer map assumes merged expert weights.
-            # Multimodal uses the model.language_model.layers prefix.
-            layer_prefix = (
-                "model.language_model.layers" if is_multimodal else "model.layers"
-            )
-            layer_prefix_re = layer_prefix.replace(".", "\\.")
-            for idx in range(text_config.num_hidden_layers):
-                gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
-                    f"{layer_prefix}.{idx}.mlp.experts.0.down_proj.weight"
-                )
-                gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
-                    f"{layer_prefix}.{idx}.mlp.experts.0.gate_proj.weight"
-                )
-                gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
-                    f"{layer_prefix}.{idx}.mlp.experts.0.up_proj.weight"
-                )
-                sideload_params.extend(
-                    [
-                        regex.compile(
-                            f"{layer_prefix_re}\\.{idx}"
-                            r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
-                        ),
-                        # Fused expert params; loaded via the per-expert names.
-                        regex.compile(
-                            f"{layer_prefix_re}\\.{idx}"
                             r"\.mlp\.experts\.(gate_up_proj|down_proj)"
                         ),
                     ]
@@ -317,19 +240,6 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 f"Failed to map GGUF parameters "
                 f"({len(unmapped_params)}): {unmapped_params}"
             )
-        # The mirror of the check above: a name mapped to a tensor no file has
-        # would load at its random init. Sideloaded params are the exceptions.
-        if gguf_tensor_names is not None:
-            missing = sorted(
-                hf_name
-                for gguf_name, hf_name in gguf_to_hf_name_map.items()
-                if gguf_name not in gguf_tensor_names
-                and not any(regex.fullmatch(p, hf_name) for p in sideload_params)
-            )
-            if missing:
-                logger.warning(
-                    "No GGUF tensor for %d mapped param(s): %s", len(missing), missing
-                )
         return gguf_to_hf_name_map
 
     def map_weights(

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
@@ -17,8 +16,10 @@ from vllm.logger import init_logger
 from ..gguf_utils import maybe_patch_hf_config_from_gguf
 from ..weight_utils import (
     get_gguf_extra_tensor_names,
+    get_gguf_shard_files,
     get_gguf_weight_type_map,
     gguf_quant_weights_iterator_multi,
+    split_stacked_experts,
 )
 from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
 
@@ -335,34 +336,10 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
         self,
         weights: Iterable[tuple[str, torch.Tensor]],
     ) -> Iterable[tuple[str, torch.Tensor]]:
-        for hf_name, weight in weights:
-            weight = self.transform_weight(hf_name, weight)
-            if weight.ndim == 3 and ".experts.0." in hf_name:
-                for expert_id, expert_weight in enumerate(weight.unbind()):
-                    expert_name = hf_name.replace(
-                        ".experts.0.", f".experts.{expert_id}."
-                    )
-                    yield expert_name, expert_weight
-            else:
-                yield hf_name, weight
-
-    @staticmethod
-    def _get_all_gguf_files(model_path: str) -> list[str]:
-        match = re.search(r"-(\d+)-of-(\d+)\.gguf$", model_path)
-        if not match:
-            return [model_path]
-        total = int(match.group(2))
-        num_digits = len(match.group(1))
-        prefix = model_path[: match.start(1)]
-        suffix = model_path[match.end(2) :]
-        files = []
-        for i in range(1, total + 1):
-            shard_path = f"{prefix}{i:0{num_digits}d}-of-{total:0{num_digits}d}{suffix}"
-            if os.path.isfile(shard_path):
-                files.append(shard_path)
-        if files:
-            logger.info("Discovered %d GGUF shard files", len(files))
-        return files if files else [model_path]
+        yield from split_stacked_experts(
+            (hf_name, self.transform_weight(hf_name, weight))
+            for hf_name, weight in weights
+        )
 
     def update_tie_word_embeddings(
         self,
@@ -374,7 +351,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
             return
 
         all_extra_names = []
-        for gguf_file in self._get_all_gguf_files(model_path):
+        for gguf_file in get_gguf_shard_files(model_path):
             all_extra_names.extend(
                 get_gguf_extra_tensor_names(gguf_file, gguf_to_hf_name_map)
             )
@@ -386,7 +363,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
         gguf_to_hf_name_map: dict[str, str],
     ) -> dict[str, str]:
         weight_type_map = {}
-        for gguf_file in self._get_all_gguf_files(model_path):
+        for gguf_file in get_gguf_shard_files(model_path):
             weight_type_map.update(
                 get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
             )
@@ -414,7 +391,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
         )
         weight_type_map = self.get_weight_type_map(model_path, gguf_to_hf_name_map)
         self.load_spec = GGUFLoadSpec(
-            weights_source=self._get_all_gguf_files(model_path),
+            weights_source=get_gguf_shard_files(model_path),
             gguf_to_hf_name_map=gguf_to_hf_name_map,
             unquantized_modules=self.get_unquantized_modules(weight_type_map),
         )

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -48,7 +48,9 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
     ):
         # gguf-py has no map for dt_bias; without this it stays zero and
         # breaks GDN recurrence. sideload is the fallback when GGUF omits it.
-        layer_prefix = "model.language_model.layers" if is_multimodal else "model.layers"
+        layer_prefix = (
+            "model.language_model.layers" if is_multimodal else "model.layers"
+        )
         for idx in range(text_config.num_hidden_layers):
             gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.bias"] = (
                 f"{layer_prefix}.{idx}.linear_attn.dt_bias"
@@ -58,6 +60,20 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
             )
         )
+
+    @staticmethod
+    def _map_qwen35_merger(gguf_to_hf_name_map):
+        # gguf-py's MMPROJ map has no linear_fc1/fc2 patterns, and llama.cpp
+        # writes the merger norm as v.post_ln.
+        for gguf_name, hf_name in (
+            ("mm.0", "linear_fc1"),
+            ("mm.2", "linear_fc2"),
+            ("v.post_ln", "norm"),
+        ):
+            for suffix in ("weight", "bias"):
+                gguf_to_hf_name_map[f"{gguf_name}.{suffix}"] = (
+                    f"model.visual.merger.{hf_name}.{suffix}"
+                )
 
     def build_name_map(self, model_config: ModelConfig) -> dict[str, str]:
         config = model_config.hf_config
@@ -142,43 +158,14 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
             )
             if is_multimodal:
-                # Manual GGUF→HF mappings for the Qwen3.5 merger (mmproj);
-                # gguf-py's MMPROJ map has no linear_fc1/fc2 patterns
-                gguf_to_hf_name_map["mm.0.weight"] = (
-                    "model.visual.merger.linear_fc1.weight"
-                )
-                gguf_to_hf_name_map["mm.0.bias"] = "model.visual.merger.linear_fc1.bias"
-                gguf_to_hf_name_map["mm.2.weight"] = (
-                    "model.visual.merger.linear_fc2.weight"
-                )
-                gguf_to_hf_name_map["mm.2.bias"] = "model.visual.merger.linear_fc2.bias"
-                gguf_to_hf_name_map["mm.input_norm.weight"] = (
-                    "model.visual.merger.norm.weight"
-                )
-                gguf_to_hf_name_map["mm.input_norm.bias"] = (
-                    "model.visual.merger.norm.bias"
-                )
+                self._map_qwen35_merger(gguf_to_hf_name_map)
         if model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
             model_type = "qwen35moe"
             self._map_gdn_dt_bias(
                 gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
             )
             if is_multimodal:
-                # Same merger mappings for the MoE variant
-                gguf_to_hf_name_map["mm.0.weight"] = (
-                    "model.visual.merger.linear_fc1.weight"
-                )
-                gguf_to_hf_name_map["mm.0.bias"] = "model.visual.merger.linear_fc1.bias"
-                gguf_to_hf_name_map["mm.2.weight"] = (
-                    "model.visual.merger.linear_fc2.weight"
-                )
-                gguf_to_hf_name_map["mm.2.bias"] = "model.visual.merger.linear_fc2.bias"
-                gguf_to_hf_name_map["mm.input_norm.weight"] = (
-                    "model.visual.merger.norm.weight"
-                )
-                gguf_to_hf_name_map["mm.input_norm.bias"] = (
-                    "model.visual.merger.norm.bias"
-                )
+                self._map_qwen35_merger(gguf_to_hf_name_map)
             # GGUF layer map assumes merged expert weights.
             # Multimodal uses the model.language_model.layers prefix.
             layer_prefix = (

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -42,6 +42,23 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
     def patch_hf_config(self, model_path: str, hf_config: PretrainedConfig):
         return maybe_patch_hf_config_from_gguf(model_path, hf_config)
 
+    @staticmethod
+    def _map_gdn_dt_bias(
+        gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
+    ):
+        # gguf-py has no map for dt_bias; without this it stays zero and
+        # breaks GDN recurrence. sideload is the fallback when GGUF omits it.
+        layer_prefix = "model.language_model.layers" if is_multimodal else "model.layers"
+        for idx in range(text_config.num_hidden_layers):
+            gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.bias"] = (
+                f"{layer_prefix}.{idx}.linear_attn.dt_bias"
+            )
+        sideload_params.append(
+            regex.compile(
+                r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
+            )
+        )
+
     def build_name_map(self, model_config: ModelConfig) -> dict[str, str]:
         config = model_config.hf_config
         text_config = config.get_text_config()
@@ -121,11 +138,8 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 )
         if model_type in ("qwen3_5", "qwen3_5_text"):
             model_type = "qwen35"
-            # dt_bias may not exist in GGUF (can be folded into dt_proj)
-            sideload_params.append(
-                regex.compile(
-                    r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
-                )
+            self._map_gdn_dt_bias(
+                gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
             )
             if is_multimodal:
                 # Manual GGUF→HF mappings for the Qwen3.5 merger (mmproj);
@@ -146,11 +160,8 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 )
         if model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
             model_type = "qwen35moe"
-            # dt_bias may not exist in GGUF (can be folded into dt_proj)
-            sideload_params.append(
-                regex.compile(
-                    r"model\.(language_model\.)?layers\.\d+\.linear_attn\.dt_bias"
-                )
+            self._map_gdn_dt_bias(
+                gguf_to_hf_name_map, sideload_params, text_config, is_multimodal
             )
             if is_multimodal:
                 # Same merger mappings for the MoE variant

--- a/vllm_gguf_plugin/weights_adapter/default.py
+++ b/vllm_gguf_plugin/weights_adapter/default.py
@@ -296,7 +296,7 @@ class GGUFWeightsAdapter(BaseGGUFWeightsAdapter):
                 gguf_name = text_name_map.get_name(base_name)
             if gguf_name is None:
                 return None
-            return gguf_name + "." + suffix
+            return f"{gguf_name}.{suffix}" if suffix else gguf_name
 
         unmapped_params = []
         for hf_name in state_dict:

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -164,6 +164,10 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             # Forced-unquantized modules keep plain params.
             if "qweight" in name and ("lm_head." in name or "embed_tokens." in name):
                 continue
+            if name.endswith(".A_log"):
+                # GGUF stores A = -exp(A_log); recover A_log for the model.
+                yield name, torch.log(-weight)
+                continue
             if "conv1d.weight" in name and weight.dim() == 2:
                 # depthwise Conv1d: [d, k] -> [d, 1, k]
                 weight = weight.unsqueeze(1)

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -168,6 +168,14 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
                 # GGUF stores A = -exp(A_log); recover A_log for the model.
                 yield name, torch.log(-weight)
                 continue
+            if (
+                name.endswith("norm.weight")
+                and not name.endswith("linear_attn.norm.weight")
+                and "visual" not in name
+            ):
+                # GGUF conversion bakes (w + 1) into these RMSNorm weights.
+                yield name, weight - 1
+                continue
             if "conv1d.weight" in name and weight.dim() == 2:
                 # depthwise Conv1d: [d, k] -> [d, 1, k]
                 weight = weight.unsqueeze(1)

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.repo_utils import list_filtered_repo_files
 
 from ..gguf_utils import detect_gguf_multimodal
-from ..weight_utils import get_gguf_weight_type_map
+from ..weight_utils import get_gguf_weight_type_map, gguf_quant_weights_iterator_multi
 from .base import GGUFLoadSpec
 from .default import GGUFWeightsAdapter
 
@@ -73,6 +73,25 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         for name in ("lm_head", "embed_tokens"):
             if name not in unquantized_modules:
                 unquantized_modules.append(name)
+
+        # llama.cpp tiles GDN V heads when num_value_heads != num_key_heads.
+        tc = self.config.get_text_config()
+        num_k = getattr(tc, "linear_num_key_heads", 0) or 0
+        num_v = getattr(tc, "linear_num_value_heads", 0) or 0
+        self._reorder = None
+        self._dequant_suffixes: tuple[str, ...] = ()
+        if num_k and num_v and num_v % num_k == 0 and num_v // num_k > 1:
+            self._reorder = {
+                "num_k": num_k,
+                "r": num_v // num_k,
+                "head_k": tc.linear_key_head_dim,
+                "head_v": tc.linear_value_head_dim,
+            }
+            # Row reorders work on packed rows; out_proj is a column
+            # reorder, so it alone needs float.
+            self._dequant_suffixes = ("linear_attn.out_proj.weight",)
+            if "linear_attn.out_proj" not in unquantized_modules:
+                unquantized_modules.append("linear_attn.out_proj")
 
         self.load_spec = GGUFLoadSpec(
             weights_source=weights_source,
@@ -148,6 +167,56 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             return ref.rsplit("/", 1)[0]
         return None
 
+    def prepare_weights(
+        self,
+        model_config: ModelConfig,
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        del model_config
+        weights = gguf_quant_weights_iterator_multi(
+            self.load_spec.weights_source,
+            self.load_spec.gguf_to_hf_name_map,
+            dequant_suffixes=("embed_tokens.weight", "lm_head.weight")
+            + self._dequant_suffixes,
+        )
+        yield from self.map_weights(weights)
+
+    @staticmethod
+    def _inv_reorder(t, dim, num_k, r, head_dim):
+        # Undo llama.cpp's grouped->tiled V-head reorder along *dim*.
+        shape = list(t.shape)
+        if dim < 0:
+            dim += len(shape)
+        t = t.reshape(*shape[:dim], r, num_k, head_dim, *shape[dim + 1 :])
+        t = t.transpose(dim, dim + 1)
+        return t.reshape(*shape).contiguous()
+
+    def _reorder_gdn(self, name: str, w: torch.Tensor) -> torch.Tensor | None:
+        """Undo llama.cpp's grouped->tiled V-head reorder. Row reorders apply
+        to packed ``qweight`` too, since GGUF quantizes per row."""
+        rc = self._reorder
+        nk, r, hk, hv = rc["num_k"], rc["r"], rc["head_k"], rc["head_v"]
+        inv = self._inv_reorder
+        if name.endswith("qweight_type"):
+            return None
+        base = name.removesuffix(".qweight").removesuffix(".weight")
+        if base.endswith(".A_log"):
+            return inv(torch.log(-w), 0, nk, r, 1)
+        if base.endswith(".dt_bias"):
+            return inv(w, 0, nk, r, 1)
+        if base.endswith("linear_attn.in_proj_z"):
+            return inv(w, 0, nk, r, hv)
+        if base.endswith(("linear_attn.in_proj_a", "linear_attn.in_proj_b")):
+            return inv(w, 0, nk, r, 1)
+        if base.endswith("linear_attn.in_proj_qkv"):
+            qk = hk * nk * 2  # q + k rows are unchanged; only V rows reorder
+            return torch.cat([w[:qk], inv(w[qk:], 0, nk, r, hv)], dim=0)
+        if base.endswith("linear_attn.out_proj"):
+            return inv(w, 1, nk, r, hv)  # column (input) reorder, dequantized
+        if base.endswith("linear_attn.conv1d") and w.dim() == 2:
+            qk = hk * nk * 2
+            return torch.cat([w[:qk], inv(w[qk:], 0, nk, r, hv)], dim=0).unsqueeze(1)
+        return None
+
     def map_weights(
         self,
         weights: Iterable[tuple[str, torch.Tensor]],
@@ -164,6 +233,12 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             # Forced-unquantized modules keep plain params.
             if "qweight" in name and ("lm_head." in name or "embed_tokens." in name):
                 continue
+            if self._reorder is not None:
+                # Also folds A_log's log(-a) recovery in the right order.
+                out = self._reorder_gdn(name, weight)
+                if out is not None:
+                    yield name, out
+                    continue
             if name.endswith(".A_log"):
                 # GGUF stores A = -exp(A_log); recover A_log for the model.
                 yield name, torch.log(-weight)

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+import torch
+from huggingface_hub import hf_hub_download
+from vllm.logger import init_logger
+from vllm.transformers_utils.repo_utils import list_filtered_repo_files
+
+from ..gguf_utils import detect_gguf_multimodal
+from ..weight_utils import get_gguf_weight_type_map
+from .base import GGUFLoadSpec
+from .default import GGUFWeightsAdapter
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+
+logger = init_logger(__name__)
+
+QWEN35_MODEL_TYPES = (
+    "qwen3_5",
+    "qwen3_5_text",
+    "qwen3_5_moe",
+    "qwen3_5_moe_text",
+)
+
+
+class Qwen35GGUFAdapter(GGUFWeightsAdapter):
+    """Adapter for Qwen3.5 dense and MoE GGUF models (Qwen3.6 reuses the
+    qwen3_5_moe architecture)."""
+
+    _reorder: dict | None = None
+    _dequant_suffixes: tuple[str, ...] = ()
+
+    @classmethod
+    def matches(cls, config) -> bool:
+        return config.model_type in QWEN35_MODEL_TYPES
+
+    def prepare_loading(
+        self,
+        model_path: str,
+        model_config: ModelConfig,
+    ) -> GGUFLoadSpec:
+        model_config.hf_config = self.patch_hf_config(
+            model_path, model_config.hf_config
+        )
+        # patch_hf_config may replace the config object (multimodal upgrade)
+        self.config = model_config.hf_config
+        mmproj_path = self._ensure_mmproj(model_path, model_config)
+
+        gguf_to_hf_name_map = self.build_name_map(model_config)
+        self.update_tie_word_embeddings(
+            model_path, model_config.hf_config, gguf_to_hf_name_map
+        )
+
+        weights_source = self._get_all_gguf_files(model_path)
+        if mmproj_path is not None:
+            weights_source.append(str(mmproj_path))
+
+        weight_type_map: dict[str, str] = {}
+        for gguf_file in weights_source:
+            weight_type_map.update(
+                get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
+            )
+        unquantized_modules = self.get_unquantized_modules(weight_type_map)
+        # ParallelLMHead / VocabParallelEmbedding take plain params only.
+        for name in ("lm_head", "embed_tokens"):
+            if name not in unquantized_modules:
+                unquantized_modules.append(name)
+
+        self.load_spec = GGUFLoadSpec(
+            weights_source=weights_source,
+            gguf_to_hf_name_map=gguf_to_hf_name_map,
+            unquantized_modules=unquantized_modules,
+        )
+        return self.load_spec
+
+    def _ensure_mmproj(self, model_path: str, model_config: ModelConfig):
+        """Locate (and download if needed) the mmproj file for multimodal
+        Qwen3.5 models. Returns its path, or None for text-only configs."""
+        if getattr(model_config.hf_config, "vision_config", None) is None:
+            return None
+
+        mmproj_path = detect_gguf_multimodal(model_path)
+        if mmproj_path is not None:
+            return mmproj_path
+
+        repo_id = self._infer_repo_id(model_config)
+        if repo_id is not None:
+            try:
+                mmproj_files = list_filtered_repo_files(
+                    repo_id,
+                    allow_patterns=["*mmproj*.gguf"],
+                    revision=model_config.revision,
+                )
+                if mmproj_files:
+                    logger.info(
+                        "Downloading mmproj file %s from %s",
+                        mmproj_files[0],
+                        repo_id,
+                    )
+                    # Download next to the backbone so detect_gguf_multimodal
+                    # finds it regardless of the configured download_dir.
+                    hf_hub_download(
+                        repo_id=repo_id,
+                        filename=mmproj_files[0],
+                        revision=model_config.revision,
+                        local_dir=os.path.dirname(model_path),
+                    )
+            except Exception as e:
+                logger.warning("Failed to download mmproj from %s: %s", repo_id, e)
+            mmproj_path = detect_gguf_multimodal(model_path)
+
+        if mmproj_path is None:
+            raise RuntimeError(
+                "Could not find mmproj file for multimodal GGUF model. "
+                "Please ensure a *mmproj*.gguf file is in the same directory "
+                "as the backbone GGUF file or available in the HF repo."
+            )
+        return mmproj_path
+
+    @staticmethod
+    def _infer_repo_id(model_config: ModelConfig) -> str | None:
+        ref = str(model_config.model_weights or model_config.model)
+        if os.path.exists(ref):
+            return None
+        if ":" in ref:
+            base, _ = ref.rsplit(":", 1)
+            return None if os.path.isdir(base) else base
+        if ref.endswith(".gguf") and "/" in ref:
+            return ref.rsplit("/", 1)[0]
+        return None
+
+    def map_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        yield from super().map_weights(self._transform_qwen35_weights(weights))
+
+    def _transform_qwen35_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        vision_config = getattr(self.config, "vision_config", None)
+        temporal_patch_size = getattr(vision_config, "temporal_patch_size", 1)
+        for name, weight in weights:
+            # Forced-unquantized modules keep plain params.
+            if "qweight" in name and ("lm_head." in name or "embed_tokens." in name):
+                continue
+            if "conv1d.weight" in name and weight.dim() == 2:
+                # depthwise Conv1d: [d, k] -> [d, 1, k]
+                weight = weight.unsqueeze(1)
+            elif (
+                temporal_patch_size > 1
+                and weight.dim() == 4
+                and "patch_embed.proj.weight" in name
+            ):
+                # GGUF mmproj stores patch_embed as a 2D conv; the model uses
+                # a 3D conv over temporal_patch_size frames. Expand to 5D.
+                weight = (
+                    weight.unsqueeze(2).repeat(1, 1, temporal_patch_size, 1, 1)
+                    / temporal_patch_size
+                )
+            elif name.endswith(".weight") and weight.dim() == 1 and "norm" not in name:
+                # GGUF flattens [1, hidden] linears (e.g. shared expert gate).
+                weight = weight.unsqueeze(0)
+            yield name, weight

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -14,7 +14,11 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.repo_utils import list_filtered_repo_files
 
 from ..gguf_utils import detect_gguf_multimodal
-from ..weight_utils import get_gguf_weight_type_map, gguf_quant_weights_iterator_multi
+from ..weight_utils import (
+    get_gguf_tensor_names,
+    get_gguf_weight_type_map,
+    gguf_quant_weights_iterator_multi,
+)
 from .base import GGUFLoadSpec
 from .default import GGUFWeightsAdapter
 
@@ -54,7 +58,13 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         self.config = model_config.hf_config
         mmproj_path = self._ensure_mmproj(model_path, model_config)
 
-        gguf_to_hf_name_map = self.build_name_map(model_config)
+        weights_source = self._get_all_gguf_files(model_path)
+        if mmproj_path is not None:
+            weights_source.append(str(mmproj_path))
+
+        gguf_to_hf_name_map = self.build_name_map(
+            model_config, get_gguf_tensor_names(weights_source)
+        )
         # Only the first Conv3d temporal slice has a gguf-py map entry.
         patch_embd = gguf_to_hf_name_map.get("v.patch_embd.weight")
         if patch_embd is not None:
@@ -65,21 +75,10 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             model_path, model_config.hf_config, gguf_to_hf_name_map
         )
 
-        weights_source = self._get_all_gguf_files(model_path)
-        if mmproj_path is not None:
-            weights_source.append(str(mmproj_path))
-
         weight_type_map: dict[str, str] = {}
         for gguf_file in weights_source:
             weight_type_map.update(
                 get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
-            )
-        # A map entry naming a tensor no GGUF file has means the param loads
-        # at its random init; build_name_map can't see this.
-        missing = sorted(set(gguf_to_hf_name_map.values()) - weight_type_map.keys())
-        if missing:
-            logger.warning(
-                "No GGUF tensor for %d mapped param(s): %s", len(missing), missing
             )
 
         unquantized_modules = self.get_unquantized_modules(weight_type_map)

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -11,6 +11,7 @@ import torch
 
 from ..gguf_utils import detect_gguf_multimodal
 from ..weight_utils import (
+    get_gguf_shard_files,
     get_gguf_tensor_names,
     get_gguf_weight_type_map,
     gguf_quant_weights_iterator_multi,
@@ -53,7 +54,7 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
 
         mmproj_path = self._ensure_mmproj(model_path)
 
-        weights_source = self._get_all_gguf_files(model_path)
+        weights_source = get_gguf_shard_files(model_path)
         if mmproj_path is not None:
             weights_source.append(str(mmproj_path))
 

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -8,19 +8,24 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
+from vllm.logger import init_logger
+from vllm.model_executor.models.utils import WeightsMapper
 
-from ..gguf_utils import detect_gguf_multimodal
+from ..gguf_utils import detect_gguf_multimodal, maybe_patch_hf_config_from_gguf
 from ..weight_utils import (
     get_gguf_shard_files,
     get_gguf_tensor_names,
-    get_gguf_weight_type_map,
+    get_gguf_unquantized_params,
     gguf_quant_weights_iterator_multi,
+    split_stacked_experts,
 )
-from .base import GGUFLoadSpec
-from .default import GGUFWeightsAdapter
+from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
 
 if TYPE_CHECKING:
+    from transformers import PretrainedConfig
     from vllm.config import ModelConfig
+
+logger = init_logger(__name__)
 
 QWEN35_MODEL_TYPES = (
     "qwen3_5",
@@ -28,18 +33,112 @@ QWEN35_MODEL_TYPES = (
     "qwen3_5_moe",
     "qwen3_5_moe_text",
 )
+QWEN35_MOE_MODEL_TYPES = ("qwen3_5_moe", "qwen3_5_moe_text")
+
+# GGUF tensors that load as plain params, so they must be dequantized on the
+# way out (names are the GGUF ones, the mapper runs afterwards).
+DEQUANT_TENSORS = ("token_embd.weight", "output.weight")
 
 
-class Qwen35GGUFAdapter(GGUFWeightsAdapter):
+def build_qwen35_text_mapper(is_multimodal: bool, is_moe: bool) -> WeightsMapper:
+    backbone_prefix = "model.language_model." if is_multimodal else "model."
+    orig_to_new_substr: dict[str, str] = {
+        "attn_norm.": "input_layernorm.",
+        "post_attention_norm.": "post_attention_layernorm.",
+        # attention
+        "attn_q_norm.": "self_attn.q_norm.",
+        "attn_k_norm.": "self_attn.k_norm.",
+        "attn_q.": "self_attn.q_proj.",
+        "attn_k.": "self_attn.k_proj.",
+        "attn_v.": "self_attn.v_proj.",
+        "attn_output.": "self_attn.o_proj.",
+        # gated delta net; llama.cpp writes the two fused in_proj halves under
+        # the attention names, the rest under ssm_*.
+        "attn_qkv.": "linear_attn.in_proj_qkv.",
+        "attn_gate.": "linear_attn.in_proj_z.",
+        "ssm_alpha.": "linear_attn.in_proj_a.",
+        "ssm_beta.": "linear_attn.in_proj_b.",
+        "ssm_conv1d.": "linear_attn.conv1d.",
+        "ssm_norm.": "linear_attn.norm.",
+        "ssm_out.": "linear_attn.out_proj.",
+        # A_log and dt_bias are bare params in the HF checkpoint, so they drop
+        # the GGUF suffix. Keep these after ssm_alpha, "ssm_a" is a prefix of it.
+        "ssm_dt.bias": "linear_attn.dt_bias",
+        "ssm_a.weight": "linear_attn.A_log",
+        "ssm_a": "linear_attn.A_log",
+    }
+    if is_moe:
+        orig_to_new_substr |= {
+            "ffn_gate_inp_shexp.": "mlp.shared_expert_gate.",
+            "ffn_gate_inp.": "mlp.gate.",
+            # Expert weights are stacked; prepare_weights splits them per expert.
+            "ffn_gate_exps.": "mlp.experts.0.gate_proj.",
+            "ffn_up_exps.": "mlp.experts.0.up_proj.",
+            "ffn_down_exps.": "mlp.experts.0.down_proj.",
+            "ffn_gate_shexp.": "mlp.shared_expert.gate_proj.",
+            "ffn_up_shexp.": "mlp.shared_expert.up_proj.",
+            "ffn_down_shexp.": "mlp.shared_expert.down_proj.",
+        }
+    else:
+        orig_to_new_substr |= {
+            "ffn_gate.": "mlp.gate_proj.",
+            "ffn_up.": "mlp.up_proj.",
+            "ffn_down.": "mlp.down_proj.",
+        }
+
+    return WeightsMapper(
+        orig_to_new_prefix={
+            "token_embd.": backbone_prefix + "embed_tokens.",
+            "blk.": backbone_prefix + "layers.",
+            "output_norm.": backbone_prefix + "norm.",
+            "output.": "lm_head.",
+        },
+        orig_to_new_substr=orig_to_new_substr,
+    )
+
+
+def build_qwen35_vision_mapper() -> WeightsMapper:
+    """Vision tower and merger. Kept apart from the text mapper because the
+    two reuse GGUF names for different modules (``attn_qkv`` is the merged QKV
+    of a vision block, but the GDN in_proj of a text layer)."""
+    return WeightsMapper(
+        orig_to_new_prefix={
+            "v.blk.": "model.visual.blocks.",
+            "v.patch_embd.": "model.visual.patch_embed.proj.",
+            "v.position_embd.": "model.visual.pos_embed.",
+            # llama.cpp writes the merger norm as v.post_ln and its MLP as mm.N.
+            "v.post_ln.": "model.visual.merger.norm.",
+            "mm.0.": "model.visual.merger.linear_fc1.",
+            "mm.2.": "model.visual.merger.linear_fc2.",
+        },
+        orig_to_new_substr={
+            "attn_qkv.": "attn.qkv.",
+            "attn_out.": "attn.proj.",
+            "ffn_up.": "mlp.linear_fc1.",
+            "ffn_down.": "mlp.linear_fc2.",
+            "ln1.": "norm1.",
+            "ln2.": "norm2.",
+        },
+    )
+
+
+class Qwen35GGUFAdapter(BaseGGUFWeightsAdapter):
     """Adapter for Qwen3.5 dense and MoE GGUF models (Qwen3.6 reuses the
     qwen3_5_moe architecture)."""
 
+    text_mapper = None
+    vision_mapper = None
+    load_spec = None
+
     _reorder: dict | None = None
-    _dequant_suffixes: tuple[str, ...] = ()
+    _dequant_tensors: tuple[str, ...] = DEQUANT_TENSORS
 
     @classmethod
     def matches(cls, config) -> bool:
         return config.model_type in QWEN35_MODEL_TYPES
+
+    def patch_hf_config(self, model_path: str, hf_config: PretrainedConfig):
+        return maybe_patch_hf_config_from_gguf(model_path, hf_config)
 
     def prepare_loading(
         self,
@@ -53,58 +152,43 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         self.config = model_config.hf_config
 
         mmproj_path = self._ensure_mmproj(model_path)
-
-        weights_source = get_gguf_shard_files(model_path)
+        gguf_files = get_gguf_shard_files(model_path)
         if mmproj_path is not None:
-            weights_source.append(str(mmproj_path))
+            gguf_files.append(str(mmproj_path))
 
-        gguf_to_hf_name_map = self.build_name_map(
-            model_config, get_gguf_tensor_names(weights_source)
+        is_moe = self.config.model_type in QWEN35_MOE_MODEL_TYPES
+        self.text_mapper = build_qwen35_text_mapper(
+            is_multimodal=mmproj_path is not None, is_moe=is_moe
         )
-        # Only the first Conv3d temporal slice has a gguf-py map entry.
-        patch_embd = gguf_to_hf_name_map.get("v.patch_embd.weight")
-        if patch_embd is not None:
-            tps = getattr(self.config.vision_config, "temporal_patch_size", 1)
-            for i in range(1, tps):
-                gguf_to_hf_name_map[f"v.patch_embd.weight.{i}"] = f"{patch_embd}.{i}"
-        self.update_tie_word_embeddings(
-            model_path, model_config.hf_config, gguf_to_hf_name_map
-        )
+        self.vision_mapper = build_qwen35_vision_mapper()
+        self._set_gdn_reorder()
 
-        weight_type_map: dict[str, str] = {}
-        for gguf_file in weights_source:
-            weight_type_map.update(
-                get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
+        unmapped = sorted(
+            name
+            for name in get_gguf_tensor_names(gguf_files)
+            if self._map_name(name) is None
+        )
+        if unmapped:
+            logger.warning(
+                "No HF name for %d GGUF tensor(s), skipping: %s",
+                len(unmapped),
+                unmapped,
             )
 
-        unquantized_modules = self.get_unquantized_modules(weight_type_map)
-        # ParallelLMHead / VocabParallelEmbedding take plain params only.
-        for name in ("lm_head", "embed_tokens"):
+        unquantized_modules = list(
+            {
+                mapped.removesuffix(".weight")
+                for param in get_gguf_unquantized_params(gguf_files)
+                if (mapped := self._map_name(param)) is not None
+                and mapped.endswith(".weight")
+            }
+        )
+        for name in self._forced_unquantized_modules():
             if name not in unquantized_modules:
                 unquantized_modules.append(name)
 
-        # llama.cpp tiles GDN V heads when num_value_heads != num_key_heads.
-        tc = self.config.get_text_config()
-        num_k = getattr(tc, "linear_num_key_heads", 0) or 0
-        num_v = getattr(tc, "linear_num_value_heads", 0) or 0
-        self._reorder = None
-        self._dequant_suffixes: tuple[str, ...] = ()
-        if num_k and num_v and num_v % num_k == 0 and num_v // num_k > 1:
-            self._reorder = {
-                "num_k": num_k,
-                "r": num_v // num_k,
-                "head_k": tc.linear_key_head_dim,
-                "head_v": tc.linear_value_head_dim,
-            }
-            # Row reorders work on packed rows; out_proj is a column
-            # reorder, so it alone needs float.
-            self._dequant_suffixes = ("linear_attn.out_proj.weight",)
-            if "linear_attn.out_proj" not in unquantized_modules:
-                unquantized_modules.append("linear_attn.out_proj")
-
         self.load_spec = GGUFLoadSpec(
-            weights_source=weights_source,
-            gguf_to_hf_name_map=gguf_to_hf_name_map,
+            weights_source=gguf_files,
             unquantized_modules=unquantized_modules,
         )
         return self.load_spec
@@ -125,6 +209,44 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             )
         return mmproj_path
 
+    def _set_gdn_reorder(self) -> None:
+        """llama.cpp tiles GDN V heads when num_value_heads != num_key_heads."""
+        tc = self.config.get_text_config()
+        num_k = getattr(tc, "linear_num_key_heads", 0) or 0
+        num_v = getattr(tc, "linear_num_value_heads", 0) or 0
+        self._reorder = None
+        self._dequant_tensors = DEQUANT_TENSORS
+        if num_k and num_v and num_v % num_k == 0 and num_v // num_k > 1:
+            self._reorder = {
+                "num_k": num_k,
+                "r": num_v // num_k,
+                "head_k": tc.linear_key_head_dim,
+                "head_v": tc.linear_value_head_dim,
+            }
+            # Row reorders work on packed rows; out_proj is a column reorder,
+            # so it alone needs float.
+            self._dequant_tensors += ("ssm_out.weight",)
+
+    def _forced_unquantized_modules(self) -> list[str]:
+        """Modules whose weights are handed over as plain params, so they must
+        not be built with the GGUF linear method."""
+        # ParallelLMHead / VocabParallelEmbedding take plain params only.
+        modules = ["lm_head", "embed_tokens"]
+        if self._reorder is not None:
+            # Dequantized for the GDN column reorder, see _set_gdn_reorder.
+            modules.append("linear_attn.out_proj")
+        return modules
+
+    def _map_name(self, gguf_name: str) -> str | None:
+        """HF name for *gguf_name*, or None when nothing maps it."""
+        mapper = (
+            self.vision_mapper
+            if gguf_name.startswith(("v.", "mm."))
+            else self.text_mapper
+        )
+        hf_name = mapper.apply_list([gguf_name])[0]
+        return hf_name if hf_name != gguf_name else None
+
     def prepare_weights(
         self,
         model_config: ModelConfig,
@@ -132,11 +254,21 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         del model_config
         weights = gguf_quant_weights_iterator_multi(
             self.load_spec.weights_source,
-            self.load_spec.gguf_to_hf_name_map,
-            dequant_suffixes=("embed_tokens.weight", "lm_head.weight")
-            + self._dequant_suffixes,
+            dequant_suffixes=self._dequant_tensors,
         )
-        yield from self.map_weights(weights)
+        mapped = self.map_names(weights)
+        yield from split_stacked_experts(self.transform_weight(mapped))
+
+    def map_names(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        for gguf_name, weight in weights:
+            # Quantized tensors arrive as .qweight / .qweight_type pairs; the
+            # mapper keys on the module part, so both map like the plain name.
+            hf_name = self._map_name(gguf_name)
+            if hf_name is not None:
+                yield hf_name, weight
 
     @staticmethod
     def _inv_reorder(t, dim, num_k, r, head_dim):
@@ -175,16 +307,11 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             return torch.cat([w[:qk], inv(w[qk:], 0, nk, r, hv)], dim=0).unsqueeze(1)
         return None
 
-    def map_weights(
+    def transform_weight(
         self,
         weights: Iterable[tuple[str, torch.Tensor]],
     ) -> Iterable[tuple[str, torch.Tensor]]:
-        yield from super().map_weights(self._transform_qwen35_weights(weights))
-
-    def _transform_qwen35_weights(
-        self,
-        weights: Iterable[tuple[str, torch.Tensor]],
-    ) -> Iterable[tuple[str, torch.Tensor]]:
+        """Transform raw GGUF weights to HF-style weights."""
         vision_config = getattr(self.config, "vision_config", None)
         temporal_patch_size = getattr(vision_config, "temporal_patch_size", 1)
         patch_embed_parts: dict[str, torch.Tensor] = {}

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
@@ -104,13 +105,15 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
                         mmproj_files[0],
                         repo_id,
                     )
-                    # Download next to the backbone so detect_gguf_multimodal
-                    # finds it regardless of the configured download_dir.
+                    # Reuse the backbone's cache root so the file lands in
+                    # the same snapshot dir and concurrent TP workers
+                    # serialize on the hub cache lock instead of clobbering
+                    # each other.
                     hf_hub_download(
                         repo_id=repo_id,
                         filename=mmproj_files[0],
                         revision=model_config.revision,
-                        local_dir=os.path.dirname(model_path),
+                        cache_dir=self._resolve_hf_cache_dir(model_path),
                     )
             except Exception as e:
                 logger.warning("Failed to download mmproj from %s: %s", repo_id, e)
@@ -123,6 +126,15 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
                 "as the backbone GGUF file or available in the HF repo."
             )
         return mmproj_path
+
+    @staticmethod
+    def _resolve_hf_cache_dir(model_path: str) -> str | None:
+        """Return the HF cache root containing *model_path* (covers custom
+        --download-dir layouts), or None for the default cache."""
+        for parent in Path(model_path).parents:
+            if parent.name.startswith("models--"):
+                return str(parent.parent)
+        return None
 
     @staticmethod
     def _infer_repo_id(model_config: ModelConfig) -> str | None:

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -74,6 +74,14 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
             weight_type_map.update(
                 get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
             )
+        # A map entry naming a tensor no GGUF file has means the param loads
+        # at its random init; build_name_map can't see this.
+        missing = sorted(set(gguf_to_hf_name_map.values()) - weight_type_map.keys())
+        if missing:
+            logger.warning(
+                "No GGUF tensor for %d mapped param(s): %s", len(missing), missing
+            )
+
         unquantized_modules = self.get_unquantized_modules(weight_type_map)
         # ParallelLMHead / VocabParallelEmbedding take plain params only.
         for name in ("lm_head", "embed_tokens"):

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -40,52 +40,60 @@ QWEN35_MOE_MODEL_TYPES = ("qwen3_5_moe", "qwen3_5_moe_text")
 DEQUANT_TENSORS = ("token_embd.weight", "output.weight")
 
 
+# Within-layer GGUF -> HF renames, shared with the MTP draft. Substr rules
+# apply in order, so entries that are prefixes of others come last.
+QWEN35_ATTN_SUBSTR: dict[str, str] = {
+    "attn_norm.": "input_layernorm.",
+    "post_attention_norm.": "post_attention_layernorm.",
+    # attention
+    "attn_q_norm.": "self_attn.q_norm.",
+    "attn_k_norm.": "self_attn.k_norm.",
+    "attn_q.": "self_attn.q_proj.",
+    "attn_k.": "self_attn.k_proj.",
+    "attn_v.": "self_attn.v_proj.",
+    "attn_output.": "self_attn.o_proj.",
+    # gated delta net; llama.cpp writes the two fused in_proj halves under
+    # the attention names, the rest under ssm_*.
+    "attn_qkv.": "linear_attn.in_proj_qkv.",
+    "attn_gate.": "linear_attn.in_proj_z.",
+    "ssm_alpha.": "linear_attn.in_proj_a.",
+    "ssm_beta.": "linear_attn.in_proj_b.",
+    "ssm_conv1d.": "linear_attn.conv1d.",
+    "ssm_norm.": "linear_attn.norm.",
+    "ssm_out.": "linear_attn.out_proj.",
+    # A_log and dt_bias are bare params in the HF checkpoint, so they drop
+    # the GGUF suffix. Keep these after ssm_alpha, "ssm_a" is a prefix of it.
+    "ssm_dt.bias": "linear_attn.dt_bias",
+    "ssm_a.weight": "linear_attn.A_log",
+    "ssm_a": "linear_attn.A_log",
+}
+
+QWEN35_MOE_SUBSTR: dict[str, str] = {
+    "ffn_gate_inp_shexp.": "mlp.shared_expert_gate.",
+    "ffn_gate_inp.": "mlp.gate.",
+    # Expert weights are stacked; prepare_weights splits them per expert.
+    "ffn_gate_exps.": "mlp.experts.0.gate_proj.",
+    "ffn_up_exps.": "mlp.experts.0.up_proj.",
+    "ffn_down_exps.": "mlp.experts.0.down_proj.",
+    "ffn_gate_shexp.": "mlp.shared_expert.gate_proj.",
+    "ffn_up_shexp.": "mlp.shared_expert.up_proj.",
+    "ffn_down_shexp.": "mlp.shared_expert.down_proj.",
+}
+
+QWEN35_DENSE_SUBSTR: dict[str, str] = {
+    "ffn_gate.": "mlp.gate_proj.",
+    "ffn_up.": "mlp.up_proj.",
+    "ffn_down.": "mlp.down_proj.",
+}
+
+
+def qwen35_layer_substr(is_moe: bool) -> dict[str, str]:
+    """Within-layer renames for a Qwen3.5 decoder block."""
+    return QWEN35_ATTN_SUBSTR | (QWEN35_MOE_SUBSTR if is_moe else QWEN35_DENSE_SUBSTR)
+
+
 def build_qwen35_text_mapper(is_multimodal: bool, is_moe: bool) -> WeightsMapper:
     backbone_prefix = "model.language_model." if is_multimodal else "model."
-    orig_to_new_substr: dict[str, str] = {
-        "attn_norm.": "input_layernorm.",
-        "post_attention_norm.": "post_attention_layernorm.",
-        # attention
-        "attn_q_norm.": "self_attn.q_norm.",
-        "attn_k_norm.": "self_attn.k_norm.",
-        "attn_q.": "self_attn.q_proj.",
-        "attn_k.": "self_attn.k_proj.",
-        "attn_v.": "self_attn.v_proj.",
-        "attn_output.": "self_attn.o_proj.",
-        # gated delta net; llama.cpp writes the two fused in_proj halves under
-        # the attention names, the rest under ssm_*.
-        "attn_qkv.": "linear_attn.in_proj_qkv.",
-        "attn_gate.": "linear_attn.in_proj_z.",
-        "ssm_alpha.": "linear_attn.in_proj_a.",
-        "ssm_beta.": "linear_attn.in_proj_b.",
-        "ssm_conv1d.": "linear_attn.conv1d.",
-        "ssm_norm.": "linear_attn.norm.",
-        "ssm_out.": "linear_attn.out_proj.",
-        # A_log and dt_bias are bare params in the HF checkpoint, so they drop
-        # the GGUF suffix. Keep these after ssm_alpha, "ssm_a" is a prefix of it.
-        "ssm_dt.bias": "linear_attn.dt_bias",
-        "ssm_a.weight": "linear_attn.A_log",
-        "ssm_a": "linear_attn.A_log",
-    }
-    if is_moe:
-        orig_to_new_substr |= {
-            "ffn_gate_inp_shexp.": "mlp.shared_expert_gate.",
-            "ffn_gate_inp.": "mlp.gate.",
-            # Expert weights are stacked; prepare_weights splits them per expert.
-            "ffn_gate_exps.": "mlp.experts.0.gate_proj.",
-            "ffn_up_exps.": "mlp.experts.0.up_proj.",
-            "ffn_down_exps.": "mlp.experts.0.down_proj.",
-            "ffn_gate_shexp.": "mlp.shared_expert.gate_proj.",
-            "ffn_up_shexp.": "mlp.shared_expert.up_proj.",
-            "ffn_down_shexp.": "mlp.shared_expert.down_proj.",
-        }
-    else:
-        orig_to_new_substr |= {
-            "ffn_gate.": "mlp.gate_proj.",
-            "ffn_up.": "mlp.up_proj.",
-            "ffn_down.": "mlp.down_proj.",
-        }
-
     return WeightsMapper(
         orig_to_new_prefix={
             "token_embd.": backbone_prefix + "embed_tokens.",
@@ -93,7 +101,7 @@ def build_qwen35_text_mapper(is_multimodal: bool, is_moe: bool) -> WeightsMapper
             "output_norm.": backbone_prefix + "norm.",
             "output.": "lm_head.",
         },
-        orig_to_new_substr=orig_to_new_substr,
+        orig_to_new_substr=qwen35_layer_substr(is_moe),
     )
 
 

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -55,6 +55,12 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         mmproj_path = self._ensure_mmproj(model_path, model_config)
 
         gguf_to_hf_name_map = self.build_name_map(model_config)
+        # Only the first Conv3d temporal slice has a gguf-py map entry.
+        patch_embd = gguf_to_hf_name_map.get("v.patch_embd.weight")
+        if patch_embd is not None:
+            tps = getattr(self.config.vision_config, "temporal_patch_size", 1)
+            for i in range(1, tps):
+                gguf_to_hf_name_map[f"v.patch_embd.weight.{i}"] = f"{patch_embd}.{i}"
         self.update_tie_word_embeddings(
             model_path, model_config.hf_config, gguf_to_hf_name_map
         )
@@ -229,6 +235,7 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
     ) -> Iterable[tuple[str, torch.Tensor]]:
         vision_config = getattr(self.config, "vision_config", None)
         temporal_patch_size = getattr(vision_config, "temporal_patch_size", 1)
+        patch_embed_parts: dict[str, torch.Tensor] = {}
         for name, weight in weights:
             # Forced-unquantized modules keep plain params.
             if "qweight" in name and ("lm_head." in name or "embed_tokens." in name):
@@ -251,20 +258,22 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
                 # GGUF conversion bakes (w + 1) into these RMSNorm weights.
                 yield name, weight - 1
                 continue
+            if temporal_patch_size > 1 and "patch_embed.proj.weight" in name:
+                # GGUF holds one 2D conv per temporal frame; stack back to 5D.
+                base, split, _ = name.rpartition(".weight.")
+                key = f"{base}.weight" if split else name
+                patch_embed_parts[name] = weight
+                parts = [patch_embed_parts.get(key)] + [
+                    patch_embed_parts.get(f"{key}.{i}")
+                    for i in range(1, temporal_patch_size)
+                ]
+                if any(part is None for part in parts):
+                    continue
+                yield key, torch.stack(parts, dim=2)
+                continue
             if "conv1d.weight" in name and weight.dim() == 2:
                 # depthwise Conv1d: [d, k] -> [d, 1, k]
                 weight = weight.unsqueeze(1)
-            elif (
-                temporal_patch_size > 1
-                and weight.dim() == 4
-                and "patch_embed.proj.weight" in name
-            ):
-                # GGUF mmproj stores patch_embed as a 2D conv; the model uses
-                # a 3D conv over temporal_patch_size frames. Expand to 5D.
-                weight = (
-                    weight.unsqueeze(2).repeat(1, 1, temporal_patch_size, 1, 1)
-                    / temporal_patch_size
-                )
             elif name.endswith(".weight") and weight.dim() == 1 and "norm" not in name:
                 # GGUF flattens [1, hidden] linears (e.g. shared expert gate).
                 weight = weight.unsqueeze(0)

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -3,15 +3,11 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
-from huggingface_hub import hf_hub_download
-from vllm.logger import init_logger
-from vllm.transformers_utils.repo_utils import list_filtered_repo_files
 
 from ..gguf_utils import detect_gguf_multimodal
 from ..weight_utils import (
@@ -24,8 +20,6 @@ from .default import GGUFWeightsAdapter
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
-
-logger = init_logger(__name__)
 
 QWEN35_MODEL_TYPES = (
     "qwen3_5",
@@ -56,7 +50,8 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         )
         # patch_hf_config may replace the config object (multimodal upgrade)
         self.config = model_config.hf_config
-        mmproj_path = self._ensure_mmproj(model_path, model_config)
+
+        mmproj_path = self._ensure_mmproj(model_path)
 
         weights_source = self._get_all_gguf_files(model_path)
         if mmproj_path is not None:
@@ -113,44 +108,14 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
         )
         return self.load_spec
 
-    def _ensure_mmproj(self, model_path: str, model_config: ModelConfig):
-        """Locate (and download if needed) the mmproj file for multimodal
-        Qwen3.5 models. Returns its path, or None for text-only configs."""
-        if getattr(model_config.hf_config, "vision_config", None) is None:
+    def _ensure_mmproj(self, model_path: str) -> Path | None:
+        """Path to the mmproj file for a multimodal Qwen3.5 config, or None
+        when the model is text-only. The loader fetches it alongside the
+        backbone."""
+        if getattr(self.config, "vision_config", None) is None:
             return None
 
         mmproj_path = detect_gguf_multimodal(model_path)
-        if mmproj_path is not None:
-            return mmproj_path
-
-        repo_id = self._infer_repo_id(model_config)
-        if repo_id is not None:
-            try:
-                mmproj_files = list_filtered_repo_files(
-                    repo_id,
-                    allow_patterns=["*mmproj*.gguf"],
-                    revision=model_config.revision,
-                )
-                if mmproj_files:
-                    logger.info(
-                        "Downloading mmproj file %s from %s",
-                        mmproj_files[0],
-                        repo_id,
-                    )
-                    # Reuse the backbone's cache root so the file lands in
-                    # the same snapshot dir and concurrent TP workers
-                    # serialize on the hub cache lock instead of clobbering
-                    # each other.
-                    hf_hub_download(
-                        repo_id=repo_id,
-                        filename=mmproj_files[0],
-                        revision=model_config.revision,
-                        cache_dir=self._resolve_hf_cache_dir(model_path),
-                    )
-            except Exception as e:
-                logger.warning("Failed to download mmproj from %s: %s", repo_id, e)
-            mmproj_path = detect_gguf_multimodal(model_path)
-
         if mmproj_path is None:
             raise RuntimeError(
                 "Could not find mmproj file for multimodal GGUF model. "
@@ -158,27 +123,6 @@ class Qwen35GGUFAdapter(GGUFWeightsAdapter):
                 "as the backbone GGUF file or available in the HF repo."
             )
         return mmproj_path
-
-    @staticmethod
-    def _resolve_hf_cache_dir(model_path: str) -> str | None:
-        """Return the HF cache root containing *model_path* (covers custom
-        --download-dir layouts), or None for the default cache."""
-        for parent in Path(model_path).parents:
-            if parent.name.startswith("models--"):
-                return str(parent.parent)
-        return None
-
-    @staticmethod
-    def _infer_repo_id(model_config: ModelConfig) -> str | None:
-        ref = str(model_config.model_weights or model_config.model)
-        if os.path.exists(ref):
-            return None
-        if ":" in ref:
-            base, _ = ref.rsplit(":", 1)
-            return None if os.path.isdir(base) else base
-        if ref.endswith(".gguf") and "/" in ref:
-            return ref.rsplit("/", 1)[0]
-        return None
 
     def prepare_weights(
         self,

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.logger import init_logger
+
+from ..gguf_utils import find_nextn_block_index
+from ..weight_utils import get_gguf_weight_type_map
+from .base import GGUFLoadSpec
+from .default import GGUFWeightsAdapter
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+
+logger = init_logger(__name__)
+
+QWEN35_MTP_MODEL_TYPES = ("qwen3_5_mtp", "qwen3_5_moe_mtp")
+
+# GGUF suffix -> HF suffix within the single MTP block. HF names follow the
+# safetensors index, which is what the draft's load_weights takes.
+_MTP_TENSORS = {
+    "nextn.eh_proj.weight": "fc.weight",
+    "nextn.enorm.weight": "pre_fc_norm_embedding.weight",
+    "nextn.hnorm.weight": "pre_fc_norm_hidden.weight",
+    "nextn.shared_head_norm.weight": "norm.weight",
+    "attn_norm.weight": "layers.0.input_layernorm.weight",
+    "post_attention_norm.weight": "layers.0.post_attention_layernorm.weight",
+    "attn_q.weight": "layers.0.self_attn.q_proj.weight",
+    "attn_k.weight": "layers.0.self_attn.k_proj.weight",
+    "attn_v.weight": "layers.0.self_attn.v_proj.weight",
+    "attn_output.weight": "layers.0.self_attn.o_proj.weight",
+    "attn_q_norm.weight": "layers.0.self_attn.q_norm.weight",
+    "attn_k_norm.weight": "layers.0.self_attn.k_norm.weight",
+    "ffn_gate_inp.weight": "layers.0.mlp.gate.weight",
+    "ffn_gate_exps.weight": "layers.0.mlp.experts.0.gate_proj.weight",
+    "ffn_up_exps.weight": "layers.0.mlp.experts.0.up_proj.weight",
+    "ffn_down_exps.weight": "layers.0.mlp.experts.0.down_proj.weight",
+    "ffn_gate_shexp.weight": "layers.0.mlp.shared_expert.gate_proj.weight",
+    "ffn_up_shexp.weight": "layers.0.mlp.shared_expert.up_proj.weight",
+    "ffn_down_shexp.weight": "layers.0.mlp.shared_expert.down_proj.weight",
+    "ffn_gate_inp_shexp.weight": "layers.0.mlp.shared_expert_gate.weight",
+}
+
+# Every MTP RMSNorm; enorm/hnorm are the two that don't end in "norm.weight".
+_MTP_NORM_SUFFIXES = ("norm.weight", "norm_embedding.weight", "norm_hidden.weight")
+
+
+class Qwen35MtpGGUFAdapter(GGUFWeightsAdapter):
+    """Adapter for the Qwen3.5/3.6 MTP draft when the GGUF carries the nextn
+    block. gguf-py has no arch for the draft's model_type, so the name map is
+    written out directly. Covers a single MTP block (mtp_num_hidden_layers=1);
+    a multi-block export would load only the first."""
+
+    @classmethod
+    def matches(cls, config) -> bool:
+        return config.model_type in QWEN35_MTP_MODEL_TYPES
+
+    @staticmethod
+    def build_mtp_name_map(block_index: int) -> dict[str, str]:
+        return {
+            f"blk.{block_index}.{gguf_suffix}": f"mtp.{hf_suffix}"
+            for gguf_suffix, hf_suffix in _MTP_TENSORS.items()
+        }
+
+    def prepare_loading(
+        self,
+        model_path: str,
+        model_config: ModelConfig,
+    ) -> GGUFLoadSpec:
+        del model_config
+        weights_source = self._get_all_gguf_files(model_path)
+        block_index = find_nextn_block_index(weights_source)
+        if block_index is None:
+            raise RuntimeError(
+                f"No MTP/nextn block in {weights_source}; this GGUF cannot "
+                "serve a speculative draft."
+            )
+        logger.info("Loading MTP draft from GGUF block %d", block_index)
+
+        gguf_to_hf_name_map = self.build_mtp_name_map(block_index)
+        weight_type_map: dict[str, str] = {}
+        for gguf_file in weights_source:
+            weight_type_map.update(
+                get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
+            )
+        missing = sorted(set(gguf_to_hf_name_map.values()) - weight_type_map.keys())
+        if missing:
+            logger.warning(
+                "No GGUF tensor for %d MTP param(s): %s", len(missing), missing
+            )
+
+        self.load_spec = GGUFLoadSpec(
+            weights_source=weights_source,
+            gguf_to_hf_name_map=gguf_to_hf_name_map,
+            unquantized_modules=self.get_unquantized_modules(weight_type_map),
+        )
+        return self.load_spec
+
+    def map_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        yield from super().map_weights(self._transform_mtp_weights(weights))
+
+    @staticmethod
+    def _transform_mtp_weights(
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        for name, weight in weights:
+            if name.endswith(_MTP_NORM_SUFFIXES):
+                # GGUF conversion bakes (w + 1) into these RMSNorm weights.
+                weight = weight - 1
+            elif name.endswith(".weight") and weight.dim() == 1:
+                # GGUF flattens shared_expert_gate [1, hidden] -> [hidden].
+                weight = weight.unsqueeze(0)
+            yield name, weight

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
@@ -10,9 +10,14 @@ import torch
 from vllm.logger import init_logger
 
 from ..gguf_utils import find_nextn_block_index
-from ..weight_utils import get_gguf_shard_files, get_gguf_weight_type_map
-from .base import GGUFLoadSpec
-from .default import GGUFWeightsAdapter
+from ..weight_utils import (
+    get_gguf_shard_files,
+    get_gguf_tensor_names,
+    get_gguf_unquantized_params,
+    gguf_quant_weights_iterator_multi,
+    split_stacked_experts,
+)
+from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -50,11 +55,13 @@ _MTP_TENSORS = {
 _MTP_NORM_SUFFIXES = ("norm.weight", "norm_embedding.weight", "norm_hidden.weight")
 
 
-class Qwen35MtpGGUFAdapter(GGUFWeightsAdapter):
+class Qwen35MtpGGUFAdapter(BaseGGUFWeightsAdapter):
     """Adapter for the Qwen3.5/3.6 MTP draft when the GGUF carries the nextn
     block. gguf-py has no arch for the draft's model_type, so the name map is
     written out directly. Covers a single MTP block (mtp_num_hidden_layers=1);
     a multi-block export would load only the first."""
+
+    load_spec = None
 
     @classmethod
     def matches(cls, config) -> bool:
@@ -73,44 +80,57 @@ class Qwen35MtpGGUFAdapter(GGUFWeightsAdapter):
         model_config: ModelConfig,
     ) -> GGUFLoadSpec:
         del model_config
-        weights_source = get_gguf_shard_files(model_path)
-        block_index = find_nextn_block_index(weights_source)
+        gguf_files = get_gguf_shard_files(model_path)
+        block_index = find_nextn_block_index(gguf_files)
         if block_index is None:
             raise RuntimeError(
-                f"No MTP/nextn block in {weights_source}; this GGUF cannot "
+                f"No MTP/nextn block in {gguf_files}; this GGUF cannot "
                 "serve a speculative draft."
             )
         logger.info("Loading MTP draft from GGUF block %d", block_index)
 
         gguf_to_hf_name_map = self.build_mtp_name_map(block_index)
-        weight_type_map: dict[str, str] = {}
-        for gguf_file in weights_source:
-            weight_type_map.update(
-                get_gguf_weight_type_map(gguf_file, gguf_to_hf_name_map)
-            )
-        missing = sorted(set(gguf_to_hf_name_map.values()) - weight_type_map.keys())
+        missing = sorted(
+            hf_name
+            for gguf_name, hf_name in gguf_to_hf_name_map.items()
+            if gguf_name not in get_gguf_tensor_names(gguf_files)
+        )
         if missing:
             logger.warning(
                 "No GGUF tensor for %d MTP param(s): %s", len(missing), missing
             )
 
+        unquantized_modules = list(
+            {
+                gguf_to_hf_name_map[param].removesuffix(".weight")
+                for param in get_gguf_unquantized_params(gguf_files)
+                if param in gguf_to_hf_name_map
+            }
+        )
+
         self.load_spec = GGUFLoadSpec(
-            weights_source=weights_source,
+            weights_source=gguf_files,
             gguf_to_hf_name_map=gguf_to_hf_name_map,
-            unquantized_modules=self.get_unquantized_modules(weight_type_map),
+            unquantized_modules=unquantized_modules,
         )
         return self.load_spec
 
-    def map_weights(
+    def prepare_weights(
         self,
-        weights: Iterable[tuple[str, torch.Tensor]],
+        model_config: ModelConfig,
     ) -> Iterable[tuple[str, torch.Tensor]]:
-        yield from super().map_weights(self._transform_mtp_weights(weights))
+        del model_config
+        weights = gguf_quant_weights_iterator_multi(
+            self.load_spec.weights_source,
+            self.load_spec.gguf_to_hf_name_map,
+        )
+        yield from split_stacked_experts(self.transform_weight(weights))
 
     @staticmethod
-    def _transform_mtp_weights(
+    def transform_weight(
         weights: Iterable[tuple[str, torch.Tensor]],
     ) -> Iterable[tuple[str, torch.Tensor]]:
+        """Transform raw GGUF weights to HF-style weights."""
         for name, weight in weights:
             if name.endswith(_MTP_NORM_SUFFIXES):
                 # GGUF conversion bakes (w + 1) into these RMSNorm weights.

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
@@ -10,7 +10,7 @@ import torch
 from vllm.logger import init_logger
 
 from ..gguf_utils import find_nextn_block_index
-from ..weight_utils import get_gguf_weight_type_map
+from ..weight_utils import get_gguf_shard_files, get_gguf_weight_type_map
 from .base import GGUFLoadSpec
 from .default import GGUFWeightsAdapter
 
@@ -73,7 +73,7 @@ class Qwen35MtpGGUFAdapter(GGUFWeightsAdapter):
         model_config: ModelConfig,
     ) -> GGUFLoadSpec:
         del model_config
-        weights_source = self._get_all_gguf_files(model_path)
+        weights_source = get_gguf_shard_files(model_path)
         block_index = find_nextn_block_index(weights_source)
         if block_index is None:
             raise RuntimeError(

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5_mtp.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import torch
 from vllm.logger import init_logger
+from vllm.model_executor.models.utils import WeightsMapper
 
 from ..gguf_utils import find_nextn_block_index
 from ..weight_utils import (
@@ -18,6 +19,7 @@ from ..weight_utils import (
     split_stacked_experts,
 )
 from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
+from .qwen3_5 import qwen35_layer_substr
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -25,54 +27,42 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 QWEN35_MTP_MODEL_TYPES = ("qwen3_5_mtp", "qwen3_5_moe_mtp")
-
-# GGUF suffix -> HF suffix within the single MTP block. HF names follow the
-# safetensors index, which is what the draft's load_weights takes.
-_MTP_TENSORS = {
-    "nextn.eh_proj.weight": "fc.weight",
-    "nextn.enorm.weight": "pre_fc_norm_embedding.weight",
-    "nextn.hnorm.weight": "pre_fc_norm_hidden.weight",
-    "nextn.shared_head_norm.weight": "norm.weight",
-    "attn_norm.weight": "layers.0.input_layernorm.weight",
-    "post_attention_norm.weight": "layers.0.post_attention_layernorm.weight",
-    "attn_q.weight": "layers.0.self_attn.q_proj.weight",
-    "attn_k.weight": "layers.0.self_attn.k_proj.weight",
-    "attn_v.weight": "layers.0.self_attn.v_proj.weight",
-    "attn_output.weight": "layers.0.self_attn.o_proj.weight",
-    "attn_q_norm.weight": "layers.0.self_attn.q_norm.weight",
-    "attn_k_norm.weight": "layers.0.self_attn.k_norm.weight",
-    "ffn_gate_inp.weight": "layers.0.mlp.gate.weight",
-    "ffn_gate_exps.weight": "layers.0.mlp.experts.0.gate_proj.weight",
-    "ffn_up_exps.weight": "layers.0.mlp.experts.0.up_proj.weight",
-    "ffn_down_exps.weight": "layers.0.mlp.experts.0.down_proj.weight",
-    "ffn_gate_shexp.weight": "layers.0.mlp.shared_expert.gate_proj.weight",
-    "ffn_up_shexp.weight": "layers.0.mlp.shared_expert.up_proj.weight",
-    "ffn_down_shexp.weight": "layers.0.mlp.shared_expert.down_proj.weight",
-    "ffn_gate_inp_shexp.weight": "layers.0.mlp.shared_expert_gate.weight",
-}
+QWEN35_MOE_MTP_MODEL_TYPES = ("qwen3_5_moe_mtp",)
 
 # Every MTP RMSNorm; enorm/hnorm are the two that don't end in "norm.weight".
 _MTP_NORM_SUFFIXES = ("norm.weight", "norm_embedding.weight", "norm_hidden.weight")
 
 
+def build_qwen35_mtp_mapper(block_index: int, is_moe: bool) -> WeightsMapper:
+    """Map the GGUF nextn block onto the draft's HF names. The block holds a
+    plain decoder layer, so only the prefixes differ from the backbone."""
+    blk = f"blk.{block_index}."
+    return WeightsMapper(
+        # nextn entries first; once one rewrites a name the generic block
+        # prefix no longer matches it.
+        orig_to_new_prefix={
+            f"{blk}nextn.eh_proj.": "mtp.fc.",
+            f"{blk}nextn.enorm.": "mtp.pre_fc_norm_embedding.",
+            f"{blk}nextn.hnorm.": "mtp.pre_fc_norm_hidden.",
+            f"{blk}nextn.shared_head_norm.": "mtp.norm.",
+            blk: "mtp.layers.0.",
+        },
+        orig_to_new_substr=qwen35_layer_substr(is_moe),
+    )
+
+
 class Qwen35MtpGGUFAdapter(BaseGGUFWeightsAdapter):
     """Adapter for the Qwen3.5/3.6 MTP draft when the GGUF carries the nextn
-    block. gguf-py has no arch for the draft's model_type, so the name map is
-    written out directly. Covers a single MTP block (mtp_num_hidden_layers=1);
-    a multi-block export would load only the first."""
+    block. gguf-py has no arch for the draft's model_type, so the names come
+    from the backbone's rules plus the nextn prefixes. Covers a single MTP
+    block (mtp_num_hidden_layers=1); a multi-block export loads only the
+    first."""
 
     load_spec = None
 
     @classmethod
     def matches(cls, config) -> bool:
         return config.model_type in QWEN35_MTP_MODEL_TYPES
-
-    @staticmethod
-    def build_mtp_name_map(block_index: int) -> dict[str, str]:
-        return {
-            f"blk.{block_index}.{gguf_suffix}": f"mtp.{hf_suffix}"
-            for gguf_suffix, hf_suffix in _MTP_TENSORS.items()
-        }
 
     def prepare_loading(
         self,
@@ -89,15 +79,25 @@ class Qwen35MtpGGUFAdapter(BaseGGUFWeightsAdapter):
             )
         logger.info("Loading MTP draft from GGUF block %d", block_index)
 
-        gguf_to_hf_name_map = self.build_mtp_name_map(block_index)
-        missing = sorted(
-            hf_name
-            for gguf_name, hf_name in gguf_to_hf_name_map.items()
-            if gguf_name not in get_gguf_tensor_names(gguf_files)
+        mapper = build_qwen35_mtp_mapper(
+            block_index,
+            is_moe=self.config.model_type in QWEN35_MOE_MTP_MODEL_TYPES,
         )
-        if missing:
+        # Only the draft block; every other tensor belongs to the backbone.
+        block_prefix = f"blk.{block_index}."
+        gguf_to_hf_name_map: dict[str, str] = {}
+        unmapped: list[str] = []
+        for name in sorted(get_gguf_tensor_names(gguf_files)):
+            if not name.startswith(block_prefix):
+                continue
+            hf_name = mapper.apply_list([name])[0]
+            if hf_name == name:
+                unmapped.append(name)
+            else:
+                gguf_to_hf_name_map[name] = hf_name
+        if unmapped:
             logger.warning(
-                "No GGUF tensor for %d MTP param(s): %s", len(missing), missing
+                "No HF name for %d MTP tensor(s), skipping: %s", len(unmapped), unmapped
             )
 
         unquantized_modules = list(


### PR DESCRIPTION
Qwen3.5/3.6 GGUFs now serve with text, image input, and MTP.

Fixes: #80 

## Testing

```bash
uv run pytest tests/test_qwen3_5_adapter.py tests/test_qwen3_5_mtp_adapter.py tests/test_gguf_utils.py tests/test_params.py tests/test_plugin.py -q
.............................................................................. [ 90%]
........                                                                       [100%]
================================== warnings summary ==================================
.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /root/vllm-gguf-plugin/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
86 passed, 14 warnings in 4.46s
```

## Serve e2e, text and image input on each

- vllm 0.25.1

```bash
# Qwen3.5 Dense
vllm serve unsloth/Qwen3.5-0.8B-GGUF:Q4_0 --tokenizer Qwen/Qwen3.5-0.8B --hf-config-path Qwen/Qwen3.5-0.8B --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3

# Qwen3.5 MoE + MTP
vllm serve unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.5-35B-A3B --hf-config-path Qwen/Qwen3.5-35B-A3B --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 -tp 2 --max-model-len 10000

# Qwen3.6 Dense
vllm serve unsloth/Qwen3.6-27B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.6-27B --hf-config-path Qwen/Qwen3.6-27B --enable-auto-tool-choice --tool-call-parser qwen3_xml --reasoning-parser qwen3 -tp 2 --max-model-len 32768 --max-num-batched-tokens 4096 --enforce-eager

# Qwen3.6 MoE
## unsloth/Qwen3.6-35B-A3B-GGUF + MTP
vllm serve unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q2_K_XL --tokenizer Qwen/Qwen3.6-35B-A3B --hf-config-path Qwen/Qwen3.6-35B-A3B --enable-auto-tool-choice --tool-call-parser qwen3_xml --reasoning-parser qwen3 -tp 2 --max-model-len 10000 --speculative-config '{"method":"mtp","num_speculative_tokens":1}'

## unsloth/Qwen3.6-35B-A3B-MTP-GGUF + MTP
vllm serve unsloth/Qwen3.6-35B-A3B-MTP-GGUF:UD-Q2_K_XL --tokenizer Qwen/Qwen3.6-35B-A3B --hf-config-path Qwen/Qwen3.6-35B-A3B --enable-auto-tool-choice --tool-call-parser qwen3_xml --reasoning-parser qwen3 -tp 2 --max-model-len 10000 --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
```
