### PR TITLE
docs: document non-isolated source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,26 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
    cd vllm-gguf-plugin
    ```
 
-2. Install the plugin in development mode:
+2. If vLLM is not already installed, install it first:
 
    ```bash
-   uv pip install -e . --torch-backend=auto
+   uv pip install vllm --torch-backend=auto
    ```
 
-Or install directly:
+3. Build and install the plugin against the PyTorch installation used by
+   vLLM:
 
-```bash
-uv pip install . --torch-backend=auto
-```
+   ```bash
+   uv pip install -e . --no-build-isolation
+   ```
+
+   Disabling build isolation ensures that the CUDA extension is compiled
+   against the same PyTorch installation used by vLLM at runtime.
 
 ## Development
+
+After completing the editable source installation above, install and run the
+development tooling:
 
 ```bash
 uv pip install -e .[dev] --torch-backend=auto


### PR DESCRIPTION
## Summary

- document dependency setup for environments with and without vLLM installed
- add -no-build-isolation for source installs
- build the CUDA extension against the PyTorch installation used by vLLM

## Validation

On my WSL2 environment:

- reproduced the failure with the previous editable source installation
- verified that the documented non-isolated installation successfully builds
  and installs `vllm-gguf-plugin==0.0.4`
- verified vLLM 0.26.0, PyTorch 2.11.0+cu130, PyTorch CUDA 13.0, and CUDA
  availability in the resulting environment

Fixes #93