### PR TITLE
[BugFix] Check and use .item() for newer versions of numpy in gguf_utils.py::extract_vision_config_from_gguf

### DIFF
--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -252,7 +252,7 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
             return None
         # Extract scalar value from GGUF field and convert to target type
         val = field.parts[-1]
-        if hasattr(val, 'item'):
+        if hasattr(val, "item"):
             val = val.item()
         config_params[param_name] = dtype(val)
 

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -251,7 +251,10 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
             )
             return None
         # Extract scalar value from GGUF field and convert to target type
-        config_params[param_name] = dtype(field.parts[-1])
+        val = field.parts[-1]
+        if hasattr(val, 'item'):
+            val = val.item()
+        config_params[param_name] = dtype(val)
 
     # Apply model-specific parameters based on projector type
     if projector_type == VisionProjectorType.GEMMA3:


### PR DESCRIPTION
In older versions of `numpy`, `int(numpy_array_with_one_element)` worked silently. However, newer versions that are compatible with `Python 3.14` raise:

`TypeError: only 0-dimensional arrays can be converted to Python scalars. `

This PR uses ` .item()` in `gguf_utils.py::extract_vision_config_from_gguf`  to extract the scalar from the 1-element array, but preserves backwards compatibility just in-case.
