### PR TITLE
Fix cross-repo GGUF revision resolution

### DIFF
--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from huggingface_hub import ResolvedRevision
 from vllm.config.load import LoadConfig
 
 from vllm_gguf_plugin.loader import GGUFModelLoader
@@ -154,6 +155,51 @@ class TestGGUFModelLoader:
         result = loader._prepare_weights(model_config)
         assert result == f"{mock_folder}/model-IQ1_S.gguf"
         mock_download.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("initial_revision", "resolved_revision", "expected_revision"),
+        [
+            (None, "b" * 40, None),
+            ("weights-branch", "b" * 40, "weights-branch"),
+            ("a" * 40, "a" * 40, "a" * 40),
+        ],
+    )
+    @patch("vllm_gguf_plugin.loader.download_gguf")
+    @patch("os.path.isdir", return_value=False)
+    @patch("os.path.isfile", return_value=False)
+    def test_prepare_weights_detaches_revision_resolved_for_another_repo(
+        self,
+        mock_isfile,
+        mock_isdir,
+        mock_download,
+        initial_revision,
+        resolved_revision,
+        expected_revision,
+    ):
+        mock_download.return_value = "/downloaded/model-Q4_0.gguf"
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        model_config = MagicMock()
+        model_config.model = "org/config-repo"
+        model_config.model_weights = "org/weights-repo:Q4_0"
+        model_config.revision = ResolvedRevision(
+            initial=initial_revision,
+            resolved=resolved_revision,
+        )
+
+        result = loader._prepare_weights(model_config)
+
+        assert result == "/downloaded/model-Q4_0.gguf"
+        mock_download.assert_called_once_with(
+            "org/weights-repo",
+            "Q4_0",
+            cache_dir=None,
+            revision=expected_revision,
+            ignore_patterns=load_config.ignore_patterns,
+        )
+        revision = mock_download.call_args.kwargs["revision"]
+        assert revision is None or type(revision) is str
 
     @patch("os.path.isfile", return_value=False)
     def test_prepare_weights_invalid_format(self, mock_isfile):

--- a/vllm_gguf_plugin/loader.py
+++ b/vllm_gguf_plugin/loader.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import torch
 import torch.nn as nn
-from huggingface_hub import hf_hub_download
+from huggingface_hub import ResolvedRevision, hf_hub_download
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
@@ -21,6 +21,23 @@ from .weight_utils import download_gguf, resolve_local_gguf
 from .weights_adapter import get_weights_adapter
 
 logger = init_logger(__name__)
+
+
+def _revision_for_weights_repo(
+    model_config: ModelConfig, weights_repo_id: str
+) -> str | None:
+    """Return a revision that is valid for the weights repository.
+
+    A ``ResolvedRevision`` is bound to the repository for which vLLM loaded
+    the model config. If the GGUF weights live in another repository, reuse
+    the user's original revision instead of that repository's resolved SHA.
+    An explicitly requested SHA remains unchanged, while ``None`` lets the
+    weights repository resolve its own default branch.
+    """
+    revision = model_config.revision
+    if isinstance(revision, ResolvedRevision) and weights_repo_id != model_config.model:
+        return revision.initial
+    return revision
 
 
 class GGUFModelLoader(BaseModelLoader):
@@ -52,7 +69,7 @@ class GGUFModelLoader(BaseModelLoader):
                 local_dir,
                 quant_type,
                 cache_dir=self.load_config.download_dir,
-                revision=model_config.revision,
+                revision=_revision_for_weights_repo(model_config, local_dir),
                 ignore_patterns=self.load_config.ignore_patterns,
             )
         # repo id/filename.gguf


### PR DESCRIPTION
- resolve GGUF download revisions against the repository that actually owns the weights
- preserve repository-bound resolved revisions for same-repository downloads
- keep explicit SHA revisions unchanged across repositories
- add regression coverage for default, named-branch, and explicit-SHA revisions

vLLM can store `ModelConfig.revision` as a Hugging Face `ResolvedRevision` bound to the repository used to load the model configuration. When `model_weights` points to a separate GGUF repository, the plugin forwarded that repository-specific resolved commit to the weights repository. The commit does not exist there, so `snapshot_download` failed with `RevisionNotFoundError`. When the configuration and weights repositories differ, this change passes the user's initial revision to the GGUF repository so it can resolve the correct commit. Same-repository downloads retain the existing resolved pin. This addresses the Qwen3 Q8_0 and OLMoE Q6_K failures in [AMD CI build 11734](https://buildkite.com/vllm/amd-ci/builds/11734/list?sid=019fd430-0043-4b76-9958-d1e2ef07a32d&tab=output).