### PR TITLE
[BugFix] Add hf_config for models that need it

### DIFF
--- a/vllm_gguf_plugin/quantization/config.py
+++ b/vllm_gguf_plugin/quantization/config.py
@@ -57,7 +57,7 @@ class GGUFConfig(QuantizationConfig):
 
     @classmethod
     def override_quantization_method(
-        cls, hf_quant_cfg: dict[str, Any], user_quant: str | None, **kwargs
+        cls, hf_quant_cfg: dict[str, Any], user_quant: str | None, hf_config: Any = None
     ) -> "QuantizationMethods | None":
         del hf_quant_cfg
         if user_quant == "gguf":

--- a/vllm_gguf_plugin/quantization/config.py
+++ b/vllm_gguf_plugin/quantization/config.py
@@ -57,7 +57,7 @@ class GGUFConfig(QuantizationConfig):
 
     @classmethod
     def override_quantization_method(
-        cls, hf_quant_cfg: dict[str, Any], user_quant: str | None
+        cls, hf_quant_cfg: dict[str, Any], user_quant: str | None, **kwargs
     ) -> "QuantizationMethods | None":
         del hf_quant_cfg
         if user_quant == "gguf":


### PR DESCRIPTION
When running:

`tests/quantization/test_quark.py::test_quark_fp8_parity`

with `vllm-ggu-plugin` installed, I received the following error message:

` TypeError: GGUFConfig.override_quantization_method() got an unexpected keyword argument 'hf_config'`

I added the `hf_config` parameter and the test runs successfully.

