### PR TITLE
[BugFix] Read the TP rank from the process group in merged column and QKV GGUF loaders

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,6 +2,7 @@
 
 import torch
 import vllm.engine.arg_utils as arg_utils_module
+import vllm.model_executor.layers.linear as linear_module
 import vllm.model_executor.layers.vocab_parallel_embedding as vocab_embedding_module
 import vllm.model_executor.parameter as parameter_module
 import vllm.transformers_utils.config as config_module
@@ -20,6 +21,7 @@ from vllm.transformers_utils.config import get_config_parser
 
 import vllm_gguf_plugin.config_parser as gguf_config_parser_module
 import vllm_gguf_plugin.quantization as gguf_quantization
+import vllm_gguf_plugin.quantization.params as gguf_params_module
 from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
 from vllm_gguf_plugin.quantization import (
@@ -294,6 +296,74 @@ def test_gguf_qkv_shards_are_padded_in_qkv_order(monkeypatch):
     assert torch.equal(layer.qweight[:4], q)
     assert torch.equal(layer.qweight[4:6], k)
     assert torch.equal(layer.qweight[6:8], v)
+
+
+def _patch_tp(monkeypatch, tp_rank: int, tp_size: int):
+    """Fake a tp_size-way TP group without initializing a process group."""
+    for module in (linear_module, parameter_module, gguf_params_module):
+        monkeypatch.setattr(module, "get_tensor_model_parallel_rank", lambda: tp_rank)
+        monkeypatch.setattr(
+            module, "get_tensor_model_parallel_world_size", lambda: tp_size
+        )
+
+
+def _load_merged_column_shard(monkeypatch, tp_rank, loaded_weight):
+    register()
+    _patch_tp(monkeypatch, tp_rank, tp_size=2)
+    layer = MergedColumnParallelLinear(
+        input_size=4,
+        output_sizes=[4, 4],
+        bias=False,
+        quant_config=OOTGGUFConfig.from_config({}),
+    )
+    layer.weight_loader_v2(layer.qweight, loaded_weight, 0)
+
+    return layer.qweight.data_container[0]
+
+
+def _load_qkv_shard(monkeypatch, tp_rank, shard_id, loaded_weight):
+    register()
+    _patch_tp(monkeypatch, tp_rank, tp_size=2)
+    layer = QKVParallelLinear(
+        hidden_size=4,
+        head_size=2,
+        total_num_heads=4,
+        total_num_kv_heads=2,
+        bias=False,
+        quant_config=OOTGGUFConfig.from_config({}),
+    )
+    layer.weight_loader_v2(layer.qweight, loaded_weight, shard_id)
+
+    return layer.qweight.data_container[0]
+
+
+def test_gguf_merged_column_shard_follows_tp_rank(monkeypatch):
+    # output_sizes=[4, 4] over tp_size=2 gives shard_size=2, so each rank must
+    # take a different half of the 4 rows the GGUF file holds for shard 0.
+    loaded_weight = torch.arange(16, dtype=torch.uint8).reshape(4, 4)
+
+    rank0 = _load_merged_column_shard(monkeypatch, 0, loaded_weight)
+    rank1 = _load_merged_column_shard(monkeypatch, 1, loaded_weight)
+
+    assert torch.equal(rank0, loaded_weight[0:2])
+    assert torch.equal(rank1, loaded_weight[2:4])
+
+
+def test_gguf_qkv_shard_follows_tp_rank(monkeypatch):
+    # total_num_heads=4 and total_num_kv_heads=2 over tp_size=2 gives
+    # num_kv_head_replicas=1, q shard_size=4 of 8 rows, k shard_size=2 of 4.
+    q = torch.arange(32, dtype=torch.uint8).reshape(8, 4)
+    k = torch.arange(16, dtype=torch.uint8).reshape(4, 4)
+
+    q_rank0 = _load_qkv_shard(monkeypatch, 0, "q", q)
+    q_rank1 = _load_qkv_shard(monkeypatch, 1, "q", q)
+    k_rank0 = _load_qkv_shard(monkeypatch, 0, "k", k)
+    k_rank1 = _load_qkv_shard(monkeypatch, 1, "k", k)
+
+    assert torch.equal(q_rank0, q[0:4])
+    assert torch.equal(q_rank1, q[4:8])
+    assert torch.equal(k_rank0, k[0:2])
+    assert torch.equal(k_rank1, k[2:4])
 
 
 def test_gguf_linear_preserves_cuda_weight_device(monkeypatch):

--- a/vllm_gguf_plugin/quantization/params.py
+++ b/vllm_gguf_plugin/quantization/params.py
@@ -243,7 +243,6 @@ class _GGUFParamLoadMixin:
 
     def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
         shard_id = kwargs.get("shard_id")
-        tp_rank = kwargs.get("tp_rank", 0)
         shard_size = kwargs.get("shard_size")
         if (
             shard_size is not None
@@ -251,12 +250,12 @@ class _GGUFParamLoadMixin:
             and shard_size > 0
             and shard_size < loaded_weight.shape[0]
         ):
+            tp_rank = get_tensor_model_parallel_rank()
             loaded_weight = loaded_weight.narrow(0, tp_rank * shard_size, shard_size)
         self._store(loaded_weight, shard_id=shard_id)
 
     def load_qkv_weight(self, loaded_weight: torch.Tensor, **kwargs):
         shard_id = kwargs.get("shard_id")
-        tp_rank = kwargs.get("tp_rank", 0)
         shard_size = kwargs.get("shard_size")
         num_kv_head_replicas = kwargs.get("num_heads", 1)
         if (
@@ -265,6 +264,7 @@ class _GGUFParamLoadMixin:
             and shard_size > 0
             and shard_size < loaded_weight.shape[0]
         ):
+            tp_rank = get_tensor_model_parallel_rank()
             effective_tp_rank = (
                 tp_rank // num_kv_head_replicas if shard_id in ("k", "v") else tp_rank
             )


### PR DESCRIPTION
Fixes #103.

### Summary

`_GGUFParamLoadMixin.load_merged_column_weight` and `load_qkv_weight` took the rank from `kwargs.get("tp_rank", 0)`. `MergedColumnParallelLinear.weight_loader_v2` and `QKVParallelLinear.weight_loader_v2` pass `shard_id`, `shard_offset`, `shard_size` and `num_heads`, never `tp_rank`. The default of 0 always won, so every rank narrowed the loaded tensor at offset 0 and kept rank 0's shard of every `gate_up_proj` and QKV weight. Nothing raises; the model just produces wrong output at `tensor_parallel_size > 1`.

The two sibling loaders in the same mixin, `load_column_parallel_weight` and `load_row_parallel_weight`, already call `get_tensor_model_parallel_rank()`. This makes the other two consistent.

### Changes

- `params.py`: both loaders call `get_tensor_model_parallel_rank()` instead of reading a kwarg that is never passed.
- The call is inside the sharding guard, not at the top of the method. `get_tensor_model_parallel_rank()` asserts the TP group is initialized, and a non-sharding load (`disable_tp=True`, where `shard_size` equals the full loaded size) must not require one. Existing tests build layers that way.
- Two tests fake a 2-way TP group by patching the rank and world size accessors, and assert the exact rows each rank keeps.

### Why not `self.tp_rank`

vLLM's own `_ColumnvLLMParameter` reads `self.tp_rank`, stamped by `LinearBase.update_param_tp_status()`. That does not work here: the params that receive weights are `GGUFUninitializedWeight[Type]Parameter`, which subclass `UninitializedParameter`, so the isinstance check on `BasevLLMParameter` skips them and the attribute never exists.

One consequence worth naming: `DCPGroupColumnParallelLinear` passes an explicit `tp_rank=rank // group_size` override, so for such a layer the global rank and the layer's rank diverge. Not reachable for GGUF today.

### Testing

Added `test_gguf_merged_column_shard_follows_tp_rank` and `test_gguf_qkv_shard_follows_tp_rank`.

The narrow offsets were verified directly against the real `_GGUFParamLoadMixin`, replaying the exact kwargs both `weight_loader_v2` methods pass. On `main`, rank 1 receives rank 0's rows for the merged column shard and for both q and k. With this change each rank receives its own rows. A separate case confirms that a non-sharding load completes with no TP group initialized, both before and after.

**Not exercised, and it needs a reviewer with the hardware:** I have no multi-GPU machine, so there is no real `tensor_parallel_size=2` run behind this. The added pytest was also not executed, because vllm does not install on macOS; its layer-construction path under real vLLM is unverified. `ruff check`, `ruff format --check` and `typos` pass at the pinned pre-commit versions.

### Risk

Low. Four lines, confined to the two loaders that were reading a kwarg no caller sends. Single-GPU behaviour is unchanged: `tp_size == 1` makes `shard_size` equal the loaded size, the guard is false, and no narrow happens.

### Pre-merge

Run the plugin against any merged-column or QKV GGUF model at `tensor_parallel_size=2` and confirm output is coherent. On `main` it is not.

### Two adjacent smells, not touched here

Reporting rather than fixing, since they are out of scope for this issue:

1. `load_column_parallel_weight` and `load_row_parallel_weight` read the *global* world size. Under `disable_tp=True` with a global TP > 1 they would shard a weight the layer intends to replicate.
2. This qkv loader divides by `num_kv_head_replicas` only for `k`/`v`, while vLLM divides for anything that is not `q`. That diverges on `index_q`/`index_k` (the DeepSeek indexer), which is not reachable via GGUF today.

Happy to open issues for either if useful.
