### PR TITLE
fix(quantization): handle mixed-precision fused layers in is_layer_skipped_gguf

### DIFF
--- a/vllm_gguf_plugin/quantization/utils.py
+++ b/vllm_gguf_plugin/quantization/utils.py
@@ -31,11 +31,12 @@ def is_layer_skipped_gguf(
             if is_skipped is None:
                 is_skipped = is_shard_skipped
             elif is_shard_skipped != is_skipped:
-                raise ValueError(
-                    f"Detected some but not all shards of {prefix} "
-                    "are quantized. All shards of fused layers "
-                    "to have the same precision."
-                )
+                # Unsloth UD / "XL" GGUFs store fused projections at mixed
+                # precision by design. vLLM 0.27's Kimi-K3 KDA layer also
+                # zeroes replicated-shard padding via `.weight`, so fused
+                # layers with heterogeneous shard types are handled as
+                # UNQUANTIZED instead of raising.
+                is_skipped = proj_name == "in_proj_qkvgfab"
     else:
         is_skipped = any(module_name in prefix for module_name in unquantized_modules)
 


### PR DESCRIPTION
This fixes two hard failures when loading mixed-precision ("UD"/"XL"-style) GGUF on vLLM 0.27 (e.g. `unsloth/Kimi-K3-GGUF` `UD-Q2_K_XL`):

1. `is_layer_skipped_gguf` raised `ValueError: Detected some but not all shards of ... are quantized` for fused layers whose shards are at different precisions — UD files are mixed by design (e.g. KDA `self_attn.in_proj_qkvgfab` in vLLM 0.27's Kimi-K3).
2. If such a fused layer were routed to the quantized path its only parameter is `qweight`, but `KimiK3DeltaAttention.__init__` writes `in_proj_qkvgfab.weight.data[...].zero_()` → `AttributeError: ... has no attribute 'weight'`.

Fix: for heterogeneous fused shards, keep `in_proj_qkvgfab` UNQUANTIZED so a real `.weight` exists and the model's own replicated-shard padding zeroing runs, instead of aborting. Other mixed fused layers remain on the quantized path.

Tested end-to-end on vLLM 0.27.0 (`vllm-openai:v0.27.0-cu129`), 8x141GB H20, TP8 + `--enable-expert-parallel`, serving `UD-Q2_K_XL` with `--quantization gguf` (text-only Kimi-K3 arch); boots and answers normally.


docker run -d \
  --name vllm-k3gguf-serve \
  --gpus '"device=0,1,2,3,4,5,6,7"' \
  --ipc=host \
  --ulimit memlock=-1 \
  --ulimit stack=67108864 \
  -v /models:/ssd1 \
  -p 31001:31001 \
  --entrypoint python3 \
  -e VLLM_USE_RUST_FRONTEND=1 \
  vllm/vllm-openai:v0.27.0-k3gguf-mxf2 \
  -m vllm.entrypoints.openai.api_server \
  --quantization gguf \
  --model /ssd1/Kimi-K3-GGUF/UD-Q2_K_XL/Kimi-K3-UD-Q2_K_XL-00001-of-00019.gguf \
  --tokenizer /ssd1/Kimi-K3-GGUF/UD-Q2_K_XL/ \
  --served-model-name Kimi-K3-GGUF \
  --max-num-seqs 5 \
  --max-model-len 262144 \
  --max-num-batched-tokens 2048 \
  --enable-prefix-caching \
  --host 0.0.0.0 \
  --port 31001 \
  --trust-remote-code \
  --enable-expert-parallel \
  --tensor-parallel-size 8 \
  --gpu-memory-utilization 0.95 \
  --no-enable-flashinfer-autotune \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --reasoning-parser kimi_k3 \
  --disable-uvicorn-access-log


Related: #92 (Kimi-K3 GGUF adapter).