### PR TITLE
[BugFix] Release GGUF shard tensors when materializing fused weights

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
+import weakref
+
 import torch
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.model_executor.layers.linear as linear_module
@@ -393,3 +396,37 @@ def test_gguf_linear_preserves_cuda_weight_device(monkeypatch):
 
     assert layer.qweight.device.type == "cuda"
     assert layer.qweight_type.device.type == "cuda"
+
+
+def test_gguf_merged_column_releases_shards_after_concat(monkeypatch):
+    register()
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+
+    quant_config = OOTGGUFConfig.from_config({})
+    layer = MergedColumnParallelLinear(
+        input_size=4,
+        output_sizes=[4, 4],
+        bias=False,
+        quant_config=quant_config,
+        disable_tp=True,
+    )
+    layer.weight_loader_v2(layer.qweight, torch.ones((4, 4), dtype=torch.uint8), 0)
+    layer.weight_loader_v2(layer.qweight, 2 * torch.ones((4, 4), dtype=torch.uint8), 1)
+    layer.weight_loader_v2(layer.qweight_type, torch.tensor(3, dtype=torch.uint8), 0)
+    layer.weight_loader_v2(layer.qweight_type, torch.tensor(3, dtype=torch.uint8), 1)
+
+    # The loading path keeps the pre-materialization parameter alive past
+    # process_weights_after_loading; hold it here so the shards can only be
+    # freed if materialization handed its containers over instead of copying.
+    source_param = layer.qweight
+    shard_refs = [weakref.ref(shard) for shard in source_param.data_container]
+
+    layer.quant_method.process_weights_after_loading(layer)
+    gc.collect()
+
+    assert layer.qweight is not source_param
+    assert not source_param.data_container
+    assert all(ref() is None for ref in shard_refs)

--- a/vllm_gguf_plugin/quantization/params.py
+++ b/vllm_gguf_plugin/quantization/params.py
@@ -352,6 +352,13 @@ def _materialize_gguf_weight_parameter(
     qweight.shard_id_map = dict(raw_param.shard_id_map)
     if hasattr(raw_param, "ignore_warning"):
         qweight.ignore_warning = raw_param.ignore_warning
+    # Hand the shard tensors over rather than sharing them: the source param
+    # outlives this call, and a second reference to the shards would keep them
+    # resident after _create_padded_weight_param builds the concatenated copy,
+    # leaving every fused layer in VRAM twice.
+    raw_param.data_container.clear()
+    raw_param.shard_id.clear()
+    raw_param.shard_id_map.clear()
     layer.register_parameter(param_name, qweight)
 
 


### PR DESCRIPTION
## Problem

`_materialize_gguf_weight_parameter` copies the per-shard tensor list onto the
new `GGUFWeightParameter`, but leaves the source parameter's containers
populated:

```python
qweight.data_container = list(raw_param.data_container)   # shares the tensors
```

The source parameter outlives this call during model loading, so when
`_create_padded_weight_param` later builds the concatenated copy and clears
*its own* list, that surviving reference keeps every shard alive.

Each fused layer (`MergedColumnParallelLinear`, `QKVParallelLinear`) therefore
stays resident **twice** for the lifetime of the process: once as the padded
parameter actually used for inference, and once as the original shards.

## Impact

Measured on a 27B Q4_K_M GGUF (17.83 GiB of weights) on a 24 GB RTX 3090, by
instrumenting `GGUFLinearMethod.process_weights_after_loading` and recording
`torch.cuda.memory_allocated()` per layer:

| | before | after |
|---|---|---|
| post-load overhead | **+5.00 GiB** | **+0.04 GiB** |
| peak allocated | 22.87 GiB → CUDA OOM | 19.24 GiB → loads |

Attribution of the +5.00 GiB before the fix: `MergedColumnParallelLinear`
+4.48 GiB (n=160), `QKVParallelLinear` +0.52 GiB (n=16), and ~0 for the
non-fused layers, i.e. exactly the fused weights, counted twice.

This is the difference between the model loading and not loading on a 24 GB
card. It affects any GGUF with fused layers, not one particular architecture.

## Fix

Hand the containers over instead of sharing them. The destination parameter has
already taken its own copies of all three attributes on the preceding lines, so
clearing the source is safe.

## Test

`test_gguf_merged_column_releases_shards_after_concat` holds the source
parameter across `process_weights_after_loading` — as the loading path does —
and asserts the shards are released.

That detail matters: an earlier version of this test let the source parameter
go out of scope, and it **passed without the fix**, because the parameter was
then immediately garbage and took its list with it. The leak only manifests
when the source parameter survives the call. The test as written fails on
`main` and passes with this change.

## Notes

Independent of the in-flight Qwen3.5 work (#98, #91) — neither touches
`_materialize_gguf_weight_parameter`, and this change is in a different part of
`params.py`, so it should not conflict.
