### PR TITLE
Add Muse Glimmer GGUF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ starting points:
 | Vision-language | Gemma 3 | Q4_0 backbone with F16 projector |
 | Vision-language | Qwen 3.5 | Q4_K_M backbone with BF16 projector |
 | Vision-language | Qwen 3.6 | UD-IQ2_XXS backbone with BF16 projector |
+| Vision-language | Muse Glimmer | Q4_K_XL backbone with Q4_K_M projector (images only) |
 | Image generation | Z-Image-Turbo | Q4_0 |
 | Image generation | FLUX.2-klein | Q8_0 |
 

--- a/tests/test_multimodal_gguf.py
+++ b/tests/test_multimodal_gguf.py
@@ -32,6 +32,10 @@ class GGUFMMTestConfig(NamedTuple):
     gguf_model_path: str
     prompts: list[str]
     image_names: list[str]
+    # Per-model, because a model whose image processor emits more patch tokens
+    # than MAX_MODEL_LEN leaves would have its prompt truncated -- and the
+    # comparison against HF would then be measuring the truncation.
+    max_model_len: int = MAX_MODEL_LEN
     mm_processor_kwargs: dict[str, Any] | None = None
 
 
@@ -94,6 +98,30 @@ QWEN35_MOE_CONFIG = GGUFMMTestConfig(
     image_names=_QWEN35_IMAGE_NAMES,
 )
 
+# No ``<|begin_of_text|>``: unlike Gemma 3, this tokenizer's post-processor
+# prepends it, so writing it here would produce two.
+_MUSE_GLIMMER_PROMPTS = [
+    (
+        "<|start|>user<|message|><|patch|>"
+        "What's the content in the center of the image?"
+        "<|eot|><|start|>assistant"
+    ),
+    ("<|start|>user<|message|><|patch|>What is the season?<|eot|><|start|>assistant"),
+]
+
+# The GGUF repo ships neither ``config.json`` nor a tokenizer, so the config has
+# to come from the original repo.  Naming it as the tokenizer is enough: the
+# plugin falls back to the tokenizer path when resolving the GGUF config source.
+MUSE_GLIMMER_CONFIG = GGUFMMTestConfig(
+    original_model="meta-models/Muse-Glimmer-30B",
+    gguf_model_path="meta-models/Muse-Glimmer-30B-GGUF:Q4_K_XL",
+    prompts=_MUSE_GLIMMER_PROMPTS,
+    image_names=_GEMMA3_IMAGE_NAMES,
+    # The image processor emits up to 4096 patch tokens on its own, so leave
+    # room for that plus the prompt.
+    max_model_len=8192,
+)
+
 GEMMA3_MODELS_TO_TEST = [
     pytest.param(GEMMA3_CONFIG, marks=pytest.mark.slow),
     pytest.param(GEMMA3_CONFIG_PAN_AND_SCAN, marks=pytest.mark.slow),
@@ -112,6 +140,7 @@ def _vllm_generate_greedy_logprobs(
     max_tokens: int,
     num_logprobs: int,
     dtype: str,
+    max_model_len: int,
     mm_processor_kwargs: dict[str, Any] | None,
 ) -> list[tuple[list[int], str, list[dict[int, float] | None]]]:
     """Run inference via vllm.LLM and return (token_ids, text, logprobs)."""
@@ -121,7 +150,7 @@ def _vllm_generate_greedy_logprobs(
         enforce_eager=True,
         dtype=dtype,
         gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-        max_model_len=MAX_MODEL_LEN,
+        max_model_len=max_model_len,
         mm_processor_kwargs=mm_processor_kwargs,
     )
     try:
@@ -260,11 +289,94 @@ def check_logprobs_close(
                 break
 
 
+# Q4_K noise has no direction, so a shift that does is the signature of a
+# conversion the adapter got wrong.  Measured across the shipped prompts and
+# three image scales, the shared prefix drifts by at most 0.20; a norm that never
+# had its offset removed shifts every logprob together and lands far outside
+# this.
+MAX_LOGPROB_BIAS = 0.5
+
+
+def check_logprobs_unbiased(
+    outputs_0_lst: list[tuple[list[int], str, list]],
+    outputs_1_lst: list[tuple[list[int], str, list]],
+    name_0: str,
+    name_1: str,
+) -> None:
+    """Compare the two runs quantitatively wherever that is meaningful.
+
+    Stricter than :func:`check_logprobs_close`, which compares nothing at all
+    while the tokens agree, tolerates the first divergence with a warning, and
+    zips the two sequences without checking their lengths -- so an empty run, a
+    truncated run, and a shared token sequence whose distribution has drifted all
+    pass it.  None of those show up as a load error for Muse Glimmer, whose four
+    conversions each produce fluent output when they are undone wrongly.
+
+    Comparison stops at the first divergence, and that boundary is the whole
+    point rather than a shortcut.  Greedy decoding conditions each step on what it
+    already emitted, so up to and including the divergence both runs share a
+    context and a logprob difference is attributable; past it they are completing
+    different sentences, and position-wise differences measure that instead.  The
+    gap is not subtle -- the same outputs drift by 0.03 to 0.20 across the shared
+    prefix and by up to 1.09 once the contexts have parted.
+
+    So the agreeing prefix, which the older comparison skips, is exactly where a
+    systematic shift is visible, and a bound there is what this adds.
+    """
+    assert len(outputs_0_lst) == len(outputs_1_lst)
+
+    for prompt_idx, (out_0, out_1) in enumerate(zip(outputs_0_lst, outputs_1_lst)):
+        ids_0, text_0, lps_0 = out_0
+        ids_1, text_1, lps_1 = out_1
+        context = f"Test {prompt_idx}:\n{name_0}: {text_0!r}\n{name_1}: {text_1!r}"
+
+        assert len(ids_0) == len(ids_1), (
+            f"{context}\ngenerated {len(ids_0)} and {len(ids_1)} tokens; a "
+            "comparison over the shorter of the two would pass on a run that "
+            "stopped early"
+        )
+        assert ids_0, f"{context}\nboth runs generated nothing"
+
+        diverged = next(
+            (idx for idx, (a, b) in enumerate(zip(ids_0, ids_1)) if a != b), None
+        )
+        if diverged is None:
+            shared = len(ids_0)
+        else:
+            shared = diverged + 1
+            divergence = (
+                f"{context}\nfirst differ at token {diverged}: "
+                f"{name_0} chose {ids_0[diverged]}, {name_1} chose "
+                f"{ids_1[diverged]}"
+            )
+            # Each side's choice has to at least be a candidate for the other.
+            # A row permutation left undone picks tokens the reference would
+            # never rank, which is what this catches.
+            assert ids_0[diverged] in lps_1[diverged], divergence
+            assert ids_1[diverged] in lps_0[diverged], divergence
+
+        differences = [
+            lps_1[idx][tok] - lps_0[idx][tok]
+            for idx, tok in enumerate(ids_0[:shared])
+            if lps_0 and lps_1 and tok in lps_0[idx] and tok in lps_1[idx]
+        ]
+        assert differences, f"{context}\nno position was comparable"
+
+        bias = sum(differences) / len(differences)
+        assert abs(bias) <= MAX_LOGPROB_BIAS, (
+            f"{context}\nmean logprob difference {bias:+.3f} over "
+            f"{len(differences)} shared positions exceeds {MAX_LOGPROB_BIAS}; "
+            "quantization noise has no direction, so a drift this one-sided "
+            "points at a norm offset or a discarded tensor"
+        )
+
+
 def run_multimodal_gguf_test(
     model: GGUFMMTestConfig,
     dtype: str,
     max_tokens: int,
     num_logprobs: int,
+    compare=check_logprobs_close,
 ) -> None:
     images = [ImageAsset(name).pil_image for name in model.image_names]
     size_factors = [0.25, 0.5, 1.0]
@@ -286,6 +398,7 @@ def run_multimodal_gguf_test(
             max_tokens=max_tokens,
             num_logprobs=num_logprobs,
             dtype=dtype,
+            max_model_len=model.max_model_len,
             mm_processor_kwargs=model.mm_processor_kwargs,
         )
         for prompts, scaled_images in inputs_per_image
@@ -304,7 +417,7 @@ def run_multimodal_gguf_test(
     ]
 
     for hf_outputs, gguf_outputs in zip(hf_outputs_per_case, gguf_outputs_per_case):
-        check_logprobs_close(
+        compare(
             outputs_0_lst=hf_outputs,
             outputs_1_lst=gguf_outputs,
             name_0="hf",
@@ -350,3 +463,126 @@ def test_qwen35_mm_gguf(
     num_logprobs: int,
 ) -> None:
     run_multimodal_gguf_test(model, dtype, max_tokens, num_logprobs)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for multimodal GGUF tests.",
+)
+@pytest.mark.parametrize(
+    "model",
+    [pytest.param(MUSE_GLIMMER_CONFIG, marks=pytest.mark.slow)],
+)
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+@pytest.mark.parametrize("max_tokens", [MAX_TOKENS])
+@pytest.mark.parametrize("num_logprobs", [NUM_LOGPROBS])
+def test_muse_glimmer_mm_gguf(
+    model: GGUFMMTestConfig,
+    dtype: str,
+    max_tokens: int,
+    num_logprobs: int,
+) -> None:
+    """Images only, compared quantitatively rather than for fluency.
+
+    Video is out of scope here rather than covered: the converter keeps only the
+    sum of the patch embedding's per-time-step blocks, so it is refused during
+    input validation instead, and ``test_plugin.py`` is what holds that gate in
+    place.
+
+    The comparison is :func:`check_logprobs_unbiased` because every conversion
+    this adapter undoes -- the Q/K row permutation, the norm offset, the
+    discarded synthetic Q/K norms, the patch embedding split -- loads cleanly
+    when it is wrong and produces fluent, incorrect text.  A comparison that
+    tolerates the first divergence cannot tell that apart from quantization
+    noise.
+    """
+    run_multimodal_gguf_test(
+        model, dtype, max_tokens, num_logprobs, compare=check_logprobs_unbiased
+    )
+
+
+def _outputs(tokens: list[int], logprob: float = -0.5, top: float = -0.1):
+    """One prompt's worth of output, with *tokens* chosen at *logprob*."""
+    return [
+        (
+            tokens,
+            "".join(chr(97 + tok % 26) for tok in tokens),
+            [{tok: logprob, -1: top} for tok in tokens],
+        )
+    ]
+
+
+def test_unbiased_check_accepts_an_identical_run():
+    reference = _outputs([1, 2, 3, 4])
+
+    check_logprobs_unbiased(reference, reference, "a", "b")
+
+
+def test_unbiased_check_accepts_noise_without_a_direction():
+    """Q4_K noise is what this comparison has to tolerate."""
+    left = _outputs([1, 2, 3, 4], logprob=-0.5)
+    right = [
+        (
+            left[0][0],
+            left[0][1],
+            [
+                {tok: lp, -1: -0.1}
+                for tok, lp in zip(left[0][0], (-0.4, -0.6, -0.45, -0.55))
+            ],
+        )
+    ]
+
+    check_logprobs_unbiased(left, right, "a", "b")
+
+
+def test_unbiased_check_rejects_a_run_that_stopped_early():
+    """The condition that let a truncated run pass: zip over the shorter side."""
+    with pytest.raises(AssertionError, match="stopped early"):
+        check_logprobs_unbiased(_outputs([1, 2, 3, 4]), _outputs([1, 2]), "a", "b")
+
+
+def test_unbiased_check_rejects_an_empty_run():
+    with pytest.raises(AssertionError, match="generated nothing"):
+        check_logprobs_unbiased(_outputs([]), _outputs([]), "a", "b")
+
+
+def test_unbiased_check_rejects_a_one_sided_logprob_shift():
+    """The condition that mattered most: same tokens, drifted distribution.
+
+    A norm whose offset was never removed looks exactly like this -- every
+    logprob pushed the same way, with the argmax often unchanged.
+    """
+    left = _outputs([1, 2, 3, 4], logprob=-0.5)
+    right = _outputs([1, 2, 3, 4], logprob=-2.0)
+
+    with pytest.raises(AssertionError, match="one-sided"):
+        check_logprobs_unbiased(left, right, "a", "b")
+
+
+def test_unbiased_check_rejects_a_choice_the_reference_would_never_rank():
+    """What an undone Q/K row permutation produces at the divergence."""
+    left = [([1, 2], "a", [{1: -0.1}, {2: -0.5}])]
+    right = [([1, 9], "b", [{1: -0.1}, {9: -0.5}])]
+
+    with pytest.raises(AssertionError, match="first differ at token"):
+        check_logprobs_unbiased(left, right, "a", "b")
+
+
+def test_unbiased_check_ignores_drift_once_the_contexts_have_parted():
+    """Pins the boundary, which is the part easiest to "strengthen" wrongly.
+
+    Greedy decoding conditions on what it already emitted, so past the divergence
+    the two runs are completing different sentences.  Comparing there reported a
+    bias of -1.0 on outputs that were both correct descriptions of the image,
+    which is measuring the divergence rather than the weights.
+    """
+    left = [([1, 2, 3, 4], "a", [{1: -0.1}, {2: -0.5, 9: -0.6}, {3: -0.5}, {4: -0.5}])]
+    right = [
+        (
+            [1, 9, 8, 7],
+            "b",
+            [{1: -0.1}, {9: -0.5, 2: -0.6}, {8: -0.5, 3: -9.0}, {7: -0.5, 4: -9.0}],
+        )
+    ]
+
+    check_logprobs_unbiased(left, right, "a", "b")

--- a/tests/test_muse_glimmer_gguf.py
+++ b/tests/test_muse_glimmer_gguf.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Muse Glimmer GGUF adapter.
+
+Every conversion this adapter undoes fails quietly when it is wrong: the weights
+load without complaint and the model generates fluent, incorrect text.  So these
+tests pin the conversions themselves rather than that loading succeeds.  They run
+on synthetic tensors and synthetic tensor names, so none of them needs the real
+30B checkpoint.
+
+Muse Glimmer GGUF checkpoints store Q/K with llama.cpp's interleaved rotary
+layout while vLLM's implementation hardcodes NEOX, so the adapter permutes rows
+on the way in.  The first group of tests pins the three properties that make the
+permutation safe to apply to packed quantized bytes.
+
+Quantized coverage uses the small synthetic sample tensors from
+``Isotr0py/test-gguf-sample`` rather than a real checkpoint, since the property
+under test is generic to any K-quant tensor.
+
+The dequantization reference is the Triton kernel, deliberately: it computes in
+fp32 and matches ``gguf.dequantize`` bit-for-bit, whereas the native CUDA/HIP
+kernel computes in fp16 (see ``csrc/gguf/dequantize.cuh``) and would turn these
+exact comparisons into tolerance comparisons.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from gguf import GGML_QUANT_SIZES, GGMLQuantizationType
+from transformers import PretrainedConfig
+
+from vllm_gguf_plugin.gguf_files import GGUFModelFiles
+from vllm_gguf_plugin.triton.dequantize.interface import ggml_dequantize_triton
+from vllm_gguf_plugin.weights_adapter import muse_glimmer as adapter_module
+from vllm_gguf_plugin.weights_adapter.muse_glimmer import (
+    MUSE_GLIMMER_ARCHITECTURES,
+    MuseGlimmerGGUFAdapter,
+    has_vision,
+    interleaved_to_neox_row_index,
+    neox_to_interleaved_row_index,
+    reconstruct_patch_embedding,
+    undo_rope_interleave,
+)
+
+from .utils import get_gguf_sample_tensors
+
+# 96 and 128 are the vision and text head_dim of the shipped Muse Glimmer
+# checkpoints; the rest are there to catch off-by-one indexing. 4 is excluded on
+# purpose: the permutation is accidentally self-inverse there, which hides bugs.
+HEAD_DIMS = [8, 16, 64, 96, 128]
+K_QUANT_TYPES = [
+    GGMLQuantizationType.Q4_K,
+    GGMLQuantizationType.Q5_K,
+    GGMLQuantizationType.Q6_K,
+]
+HIDDEN_SIZES = [256, 1024]
+
+
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+@pytest.mark.parametrize("num_heads", [1, 2, 32])
+def test_forward_and_inverse_index_compose_to_identity(num_heads, head_dim):
+    forward = neox_to_interleaved_row_index(num_heads, head_dim)
+    inverse = interleaved_to_neox_row_index(num_heads, head_dim)
+    identity = torch.arange(num_heads * head_dim)
+
+    torch.testing.assert_close(forward[inverse], identity)
+    torch.testing.assert_close(inverse[forward], identity)
+
+
+@pytest.mark.parametrize("head_dim", [8, 16, 64, 128])
+def test_inverse_index_is_not_self_inverse(head_dim):
+    """Guards the most likely way to get this wrong.
+
+    Applying the permutation twice looks like an inverse for head_dim == 4 but
+    diverges for every larger size, so a helper that calls the forward function
+    twice passes toy tests and corrupts real checkpoints.
+    """
+    inverse = interleaved_to_neox_row_index(2, head_dim)
+    identity = torch.arange(2 * head_dim)
+
+    assert not torch.equal(inverse[inverse], identity)
+
+
+def test_head_dim_four_is_the_misleading_case():
+    """Documents why head_dim == 4 must not be used as the only test size."""
+    inverse = interleaved_to_neox_row_index(1, 4)
+
+    assert torch.equal(inverse[inverse], torch.arange(4))
+
+
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+def test_undo_rope_interleave_inverts_the_conversion(head_dim):
+    """End-to-end on float rows: forward re-layout then undo is the identity."""
+    num_heads = 4
+    original = torch.randn(num_heads * head_dim, 7)
+
+    converted = original.index_select(
+        0, neox_to_interleaved_row_index(num_heads, head_dim)
+    )
+    assert not torch.equal(converted, original)
+
+    torch.testing.assert_close(
+        undo_rope_interleave(converted, num_heads, head_dim), original
+    )
+
+
+def test_undo_rope_interleave_rejects_row_count_mismatch():
+    with pytest.raises(ValueError, match="expected 256 rows"):
+        undo_rope_interleave(torch.zeros(255, 4), num_heads=2, head_dim=128)
+
+
+def test_odd_head_dim_is_rejected():
+    with pytest.raises(ValueError, match="head_dim must be even"):
+        interleaved_to_neox_row_index(1, 7)
+
+
+@pytest.mark.parametrize("quant_type", K_QUANT_TYPES)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+def test_qweight_rows_are_self_contained_byte_runs(quant_type, hidden_size):
+    """Super-blocks split along the input dim, so a row is whole blocks.
+
+    This is the precondition that lets the adapter permute packed bytes at all.
+    """
+    block_size, type_size = GGML_QUANT_SIZES[quant_type]
+
+    for tensor in get_gguf_sample_tensors(hidden_size, quant_type):
+        qweight = torch.tensor(tensor.data)
+        assert qweight.ndim == 2
+        row_bytes = qweight.shape[1]
+
+        assert row_bytes % type_size == 0, (
+            f"{tensor.name}: row of {row_bytes} bytes is not a whole number of "
+            f"{type_size}-byte blocks"
+        )
+        assert (row_bytes // type_size) * block_size == hidden_size
+
+
+@pytest.mark.parametrize("quant_type", K_QUANT_TYPES)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+def test_qweight_byte_permutation_round_trips(quant_type, hidden_size):
+    """Permuting packed bytes forward then back recovers the original bytes."""
+    head_dim = 128
+
+    for tensor in get_gguf_sample_tensors(hidden_size, quant_type):
+        qweight = torch.tensor(tensor.data)
+        num_rows = qweight.shape[0]
+        if num_rows % head_dim:
+            continue
+        num_heads = num_rows // head_dim
+
+        forward = qweight.index_select(
+            0, neox_to_interleaved_row_index(num_heads, head_dim)
+        )
+        restored = undo_rope_interleave(forward, num_heads, head_dim)
+
+        assert torch.equal(restored, qweight), f"{tensor.name}: bytes changed"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+@pytest.mark.parametrize("quant_type", K_QUANT_TYPES)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+def test_permute_then_dequantize_equals_dequantize_then_permute(
+    quant_type, hidden_size
+):
+    """The load-bearing equivalence: reordering bytes is safe.
+
+    If this holds, the adapter can permute rows in the quantized domain at zero
+    memory cost and zero precision loss, instead of dequantizing Q/K (which
+    would drag the whole fused QKV projection to bf16).
+    """
+    head_dim = 128
+    block_size, type_size = GGML_QUANT_SIZES[quant_type]
+    checked = 0
+
+    for tensor in get_gguf_sample_tensors(hidden_size, quant_type):
+        qweight = torch.tensor(tensor.data).cuda()
+        num_rows, row_bytes = qweight.shape
+        if num_rows % head_dim:
+            continue
+        num_heads = num_rows // head_dim
+        shape = (num_rows, row_bytes // type_size * block_size)
+
+        straight = ggml_dequantize_triton(
+            qweight, int(quant_type), *shape, torch.float32
+        )
+        permuted_first = ggml_dequantize_triton(
+            undo_rope_interleave(qweight, num_heads, head_dim),
+            int(quant_type),
+            *shape,
+            torch.float32,
+        )
+        dequantized_first = undo_rope_interleave(straight, num_heads, head_dim)
+
+        # Without this the equality below would also hold for a no-op permutation.
+        assert not torch.equal(permuted_first, straight), (
+            f"{tensor.name}: permutation had no effect, equality is vacuous"
+        )
+        assert torch.equal(permuted_first, dequantized_first), (
+            f"{tensor.name}: permuting bytes and permuting floats disagree"
+        )
+        checked += 1
+
+    assert checked, "no sample tensor had a row count divisible by head_dim"
+
+
+# --------------------------------------------------------------------------
+# Which weights the adapter loads at all
+# --------------------------------------------------------------------------
+VISION_LAYERS = (0, 1)
+# The GGUF side of the naming, which belongs to the file format rather than to
+# this plugin, so it is spelled out here instead of read back off the mapper.
+_VISION_LEAVES = ("attn_q", "attn_k", "attn_v", "attn_out")
+
+
+def _vision_config(**kwargs) -> PretrainedConfig:
+    config = PretrainedConfig()
+    config.vision_config = PretrainedConfig()
+    for key, value in kwargs.items():
+        setattr(config, key, value)
+    return config
+
+
+def test_has_vision_matches_the_rule_vllm_applies():
+    """The two have to stay the same rule, so compare against vLLM's own.
+
+    The adapter decides which weights to produce and vLLM decides which modules
+    to build.  Whenever the two disagree, one side has weights the other has
+    nowhere to put -- so this pins them together rather than trusting that a
+    copied predicate stays a copy.
+    """
+    from vllm.model_executor.models.muse_glimmer import _muse_glimmer_has_vision
+
+    configs = [
+        _vision_config(),
+        _vision_config(has_vision=True),
+        _vision_config(has_vision=False),
+        PretrainedConfig(),
+    ]
+
+    for config in configs:
+        assert has_vision(config) == _muse_glimmer_has_vision(config)
+
+    # Spelled out as well, so a change to both at once still has to be deliberate.
+    assert [has_vision(config) for config in configs] == [True, True, False, False]
+
+
+def test_architecture_names_the_class_vllm_will_build():
+    """Crossing the two model types is another failure that does not raise.
+
+    Neither type can be looked up in the mapping the config parser consults, so
+    the adapter has to name the class itself.  Pointing the multimodal type at
+    the causal-LM class loads and generates perfectly well -- as a model with no
+    vision tower at all -- so this checks both against their real sources rather
+    than against a copy of the same dict.
+    """
+    from transformers.models.auto.modeling_auto import (
+        MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+    )
+    from vllm.model_executor.models.registry import ModelRegistry
+
+    assert (
+        MUSE_GLIMMER_ARCHITECTURES["muse_glimmer"]
+        == (MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES["muse_glimmer"])
+    )
+    assert (
+        MUSE_GLIMMER_ARCHITECTURES["muse_glimmer_text"]
+        != (MUSE_GLIMMER_ARCHITECTURES["muse_glimmer"])
+    )
+
+    supported = ModelRegistry.get_supported_archs()
+    for model_type, architecture in MUSE_GLIMMER_ARCHITECTURES.items():
+        config = SimpleNamespace(model_type=model_type)
+        assert MuseGlimmerGGUFAdapter.matches(config)
+        assert MuseGlimmerGGUFAdapter.architecture(config) == architecture
+        assert architecture in supported
+
+
+def _build(monkeypatch, config, *, projector: str | None, gguf_names=()):
+    """Drive the adapter through the loader's sequence, without real files."""
+    monkeypatch.setattr(
+        adapter_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda _path, cfg, mmproj_path=None: cfg,
+    )
+    monkeypatch.setattr(
+        adapter_module, "get_gguf_tensor_names", lambda _files: list(gguf_names)
+    )
+
+    files = GGUFModelFiles(backbone=("backbone.gguf",), mm_proj=projector)
+    adapter = MuseGlimmerGGUFAdapter()
+    patched = adapter.patch_hf_config(files, config)
+    name_map = adapter.build_name_map(files, SimpleNamespace(hf_config=patched))
+    return adapter, name_map
+
+
+_PROJECTOR_NAMES = ("v.blk.0.attn_q.weight", "mm.2.weight")
+
+
+def test_projector_weights_are_mapped_when_vision_is_on(monkeypatch):
+    _, name_map = _build(
+        monkeypatch,
+        _vision_config(),
+        projector="mmproj.gguf",
+        gguf_names=_PROJECTOR_NAMES,
+    )
+
+    assert sorted(name_map) == sorted(_PROJECTOR_NAMES)
+
+
+def test_missing_projector_fails_instead_of_loading_half_a_model(monkeypatch):
+    """A silent partial load is the failure worth preventing here.
+
+    Requesting one quantization of a repo does not bring the projector along,
+    since it is quantized separately.  The config still describes a vision tower,
+    so vLLM builds one and simply never receives its weights -- which text
+    prompts do not reveal, and image prompts reveal only as bad output.
+    """
+    with pytest.raises(RuntimeError, match="mmproj"):
+        _build(monkeypatch, _vision_config(), projector=None)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(_vision_config(has_vision=False), id="vision_turned_off"),
+        pytest.param(PretrainedConfig(), id="text_only_config"),
+    ],
+)
+def test_projector_weights_are_left_out_when_vision_is_off(monkeypatch, config):
+    """Text-only runs must not pick the projector up off the directory.
+
+    The loader resolves the projector from the directory, and downloads one when
+    the config carries a ``vision_config``, so it arrives whether or not this run
+    wants it.  vLLM builds no vision tower for either config here, so leaving
+    those tensors out of the map is what keeps 809 weights from arriving with
+    nowhere to go.
+    """
+    _, name_map = _build(
+        monkeypatch, config, projector="mmproj.gguf", gguf_names=_PROJECTOR_NAMES
+    )
+
+    assert name_map == {}
+
+
+# --------------------------------------------------------------------------
+# Name mapping
+# --------------------------------------------------------------------------
+def test_synthesized_qk_norms_are_discarded(monkeypatch, caplog):
+    """These are not learned parameters and loading them applies a factor twice.
+
+    The converter synthesizes them as constants from the config's scale factor,
+    which vLLM already applies itself.  They are also checked not to be reported
+    as unmapped: that warning is for names the mapping failed to cover, and
+    listing a deliberate omission there would send the next reader after a
+    mapping bug that does not exist.
+    """
+    names = [f"blk.0.attn_{proj}_norm.weight" for proj in ("q", "k")]
+
+    _, name_map = _build(
+        monkeypatch, _vision_config(), projector="mmproj.gguf", gguf_names=names
+    )
+
+    assert name_map == {}
+    assert "No HF name" not in caplog.text
+
+
+def test_text_and_vision_projections_are_told_apart(monkeypatch):
+    """Both towers call the projection ``attn_q`` in GGUF; the targets differ.
+
+    The text module ``self_attn.q_proj`` ends with the vision module's
+    ``attn.q_proj``, so a substring rule alone would rewrite vision names into
+    text ones.
+    """
+    _, name_map = _build(
+        monkeypatch,
+        _vision_config(),
+        projector="mmproj.gguf",
+        gguf_names=["blk.0.attn_q.weight", "v.blk.0.attn_q.weight"],
+    )
+
+    assert name_map == {
+        "blk.0.attn_q.weight": (
+            "model.language_model.layers.0.self_attn.q_proj.weight"
+        ),
+        "v.blk.0.attn_q.weight": "model.vision_tower.layers.0.attn.q_proj.weight",
+    }
+
+
+# --------------------------------------------------------------------------
+# Declaring the dequantized modules unquantized
+# --------------------------------------------------------------------------
+def test_declaration_cannot_be_read_before_the_name_map_is_built():
+    """It is derived from the name map, so reading it early would under-declare.
+
+    The loader builds the map first today.  Were the declaration assigned during
+    that call rather than derived from it, a reordering on the loader's side
+    would quietly return an empty list -- and an under-declared fused layer
+    allocates packed buffers that no incoming tensor fills.
+    """
+    adapter = MuseGlimmerGGUFAdapter()
+
+    with pytest.raises(RuntimeError, match="before build_name_map"):
+        _ = adapter.extra_unquantized_modules
+
+
+def _declaration_as_vllm_sees_it(monkeypatch) -> tuple[list[str], dict[str, list[str]]]:
+    """What the adapter declared, in vLLM's namespace.
+
+    Taken from the adapter rather than assembled here, so that dropping either
+    half of the declaration shows up as a failure instead of leaving the test
+    agreeing with itself.
+
+    Three steps at runtime: the loader records HF names, vLLM rewrites them with
+    ``apply_vllm_mapper``, and the prefix ``get_quant_method`` receives is a vLLM
+    name too.  Nearly every name changes on the way through -- the text tower
+    loses ``model.language_model.`` and ``model.vision_tower.`` becomes
+    ``vision_encoder.`` -- so a declaration that only agrees with itself in HF
+    names says nothing about what happens at load time.
+
+    The loader's own half of the declaration -- the modules it derives from the
+    tensors a GGUF stores unquantized -- is left out on purpose, which is what
+    passing only synthetic names achieves.  Real checkpoints carry attention
+    biases among those, whose full paths cover the fused ``qkv_proj`` for free;
+    relying on that is what kept ``o_proj`` looking covered while it was not.
+    """
+    from vllm.model_executor.models.muse_glimmer import MuseGlimmerForCausalLM
+
+    from vllm_gguf_plugin.quantization.config import GGUFConfig
+
+    gguf_names = [
+        f"v.blk.{layer}.{leaf}.weight"
+        for layer in VISION_LAYERS
+        for leaf in _VISION_LEAVES
+    ] + ["token_embd.weight", "mm.2.weight"]
+
+    adapter, _ = _build(
+        monkeypatch,
+        _vision_config(),
+        projector="mmproj.gguf",
+        gguf_names=gguf_names,
+    )
+
+    config = GGUFConfig(unquantized_modules=list(adapter.extra_unquantized_modules))
+    config.apply_vllm_mapper(
+        MuseGlimmerForCausalLM.hf_to_vllm_mapper.get_unstacked_mapper()
+    )
+    return config.unquantized_modules, MuseGlimmerForCausalLM.packed_modules_mapping
+
+
+@pytest.mark.parametrize("layer", VISION_LAYERS)
+@pytest.mark.parametrize("projection", ["qkv_proj", "o_proj"])
+def test_dequantized_vision_layers_are_declared_unquantized(
+    monkeypatch, layer, projection
+):
+    """Whatever is dequantized has to be judged unquantized -- one decision.
+
+    The adapter hands these modules plain float ``weight``.  If
+    ``get_quant_method`` thinks they are quantized it allocates ``qweight``
+    buffers that no incoming tensor fills.
+
+    Nothing reaches that branch today, because vLLM builds these layers without
+    forwarding ``quant_config`` -- which is what forced the dequantization in the
+    first place.  So this guards the day vLLM forwards it, when a missing
+    declaration turns into a hard error.
+
+    The two projections are covered by different halves of the declaration, which
+    is why both are checked: ``qkv_proj`` is fused, and the fused branch of
+    ``is_layer_skipped_gguf`` asks whether a declared name *contains* the shard's
+    full path, so only a full-depth name matches it -- while ``o_proj`` is
+    renamed on vLLM's way in (from ``attn.proj``) and is reached only by the
+    coarse prefix.
+    """
+    from vllm_gguf_plugin.quantization.utils import is_layer_skipped_gguf
+
+    declared, fused_mapping = _declaration_as_vllm_sees_it(monkeypatch)
+    prefix = f"vision_encoder.transformer.{layer}.attn.{projection}"
+
+    assert is_layer_skipped_gguf(prefix, declared, fused_mapping), (
+        f"{prefix} is handed a dequantized float weight but is not declared "
+        "unquantized; once vLLM forwards quant_config it would allocate qweight "
+        "buffers nothing fills"
+    )
+
+
+def test_embedding_is_declared_unquantized(monkeypatch):
+    from vllm_gguf_plugin.quantization.utils import is_layer_skipped_gguf
+
+    declared, fused_mapping = _declaration_as_vllm_sees_it(monkeypatch)
+
+    assert is_layer_skipped_gguf("model.embed_tokens", declared, fused_mapping)
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "model.layers.0.self_attn.qkv_proj",
+        "model.layers.0.self_attn.o_proj",
+        "model.layers.0.mlp.gate_up_proj",
+        "model.layers.0.mlp.down_proj",
+        "lm_head",
+    ],
+)
+def test_text_layers_stay_quantized(monkeypatch, prefix):
+    """The declaration is matched by substring, which is easy to overreach with.
+
+    One declared name that is too short also marks the text tower unquantized,
+    and vLLM would then build plain float weights for layers the adapter feeds
+    packed bytes -- losing the whole 30B backbone.
+    """
+    from vllm_gguf_plugin.quantization.utils import is_layer_skipped_gguf
+
+    declared, fused_mapping = _declaration_as_vllm_sees_it(monkeypatch)
+
+    assert not is_layer_skipped_gguf(prefix, declared, fused_mapping)
+
+
+# --------------------------------------------------------------------------
+# Patch embedding
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("patch_temporal", [1, 2, 4])
+def test_patch_embedding_split_adds_back_to_the_stored_sum(patch_temporal):
+    """Only the sum survives conversion, and still images depend on just the sum.
+
+    The encoder feeds a still image to every time step by expanding the same
+    patch, so any split that adds back to the stored sum is equivalent for
+    images -- which is what makes the image path exact rather than approximate.
+    """
+    out_channels = 3
+    summed = torch.randn(out_channels, 5)
+
+    blocks = reconstruct_patch_embedding(summed, patch_temporal)
+
+    assert blocks.shape == (out_channels, 5 * patch_temporal)
+    torch.testing.assert_close(
+        blocks.reshape(out_channels, patch_temporal, 5).sum(dim=1), summed
+    )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,7 +2,9 @@
 
 import gc
 import weakref
+from types import SimpleNamespace
 
+import pytest
 import torch
 import vllm.engine.arg_utils as arg_utils_module
 import vllm.model_executor.layers.linear as linear_module
@@ -430,3 +432,60 @@ def test_gguf_merged_column_releases_shards_after_concat(monkeypatch):
     assert layer.qweight is not source_param
     assert not source_param.data_container
     assert all(ref() is None for ref in shard_refs)
+
+
+def _supported_mm_limits(quantization: str | None, model_type: str) -> dict:
+    """Evaluate the patched ``supported_mm_limits`` without starting an engine.
+
+    The wrapper installed by ``register()`` is what is under test, so this calls
+    the property directly.  Reading the effect off a rejected request instead
+    would mean loading a model, and the assertion would be buried in it.
+    """
+    from vllm.multimodal.processing.context import BaseProcessingInfo
+
+    register()
+
+    hf_config = PretrainedConfig()
+    hf_config.model_type = model_type
+
+    class Info(BaseProcessingInfo):
+        def __init__(self):
+            self.ctx = SimpleNamespace(
+                model_config=SimpleNamespace(
+                    quantization=quantization, hf_config=hf_config
+                )
+            )
+
+        def get_supported_mm_limits(self):
+            return {"image": None, "video": None}
+
+    return dict(Info().supported_mm_limits)
+
+
+def test_gguf_hides_a_modality_the_adapter_cannot_reconstruct():
+    """Muse Glimmer's converter keeps only the sum over the patch embedding's
+    time steps, so video cannot be reconstructed from these weights.
+
+    Dropping the modality here makes vLLM refuse the request with its own
+    validation error.  The alternative is worse than a refusal: video would run
+    on a reconstruction that is off by roughly 7% in the one channel carrying
+    frame-to-frame motion, and produce a fluent description of the wrong thing.
+    """
+    assert "video" not in _supported_mm_limits("gguf", "muse_glimmer")
+
+
+def test_the_modality_gate_leaves_images_alone():
+    """Positive control: the gate has to be per-modality, not per-model."""
+    assert "image" in _supported_mm_limits("gguf", "muse_glimmer")
+
+
+def test_the_modality_gate_is_tied_to_gguf():
+    """Negative control: the limitation comes from the GGUF conversion, so
+    unquantized weights of the same architecture keep video."""
+    assert "video" in _supported_mm_limits(None, "muse_glimmer")
+
+
+@pytest.mark.parametrize("model_type", ["gemma3", "qwen2_vl", "llama"])
+def test_the_modality_gate_does_not_reach_other_architectures(model_type):
+    """Negative control: the patch is global, so it has to stay adapter-scoped."""
+    assert "video" in _supported_mm_limits("gguf", model_type)

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from functools import wraps
+from functools import cached_property, wraps
 from pathlib import Path
 
 import vllm.engine.arg_utils as arg_utils_module
@@ -118,6 +118,54 @@ def _patch_speculator_probe() -> None:
     config_module._gguf_speculator_probe_patched = True
 
 
+def _gguf_unsupported_modalities(model_config) -> tuple[str, ...]:
+    if getattr(model_config, "quantization", None) != "gguf":
+        return ()
+    hf_config = getattr(model_config, "hf_config", None)
+    if hf_config is None:
+        return ()
+
+    from .weights_adapter import get_weights_adapter
+
+    return tuple(get_weights_adapter(hf_config).UNSUPPORTED_MODALITIES)
+
+
+def _patch_mm_limits() -> None:
+    """Hide modalities an adapter cannot reconstruct from its GGUF weights.
+
+    Wrapping the base ``supported_mm_limits`` rather than each model's
+    ``get_supported_mm_limits`` covers every subclass at once, and every
+    consumer -- request validation, the advertised modality list, and profiling
+    -- reads that one property. Dropping a modality from it makes vLLM reject
+    those requests with its usual validation error.
+    """
+    from vllm.multimodal.processing.context import BaseProcessingInfo
+
+    if getattr(BaseProcessingInfo, "_gguf_mm_limits_patched", False):
+        return
+
+    original = BaseProcessingInfo.supported_mm_limits.func
+
+    @wraps(original)
+    def supported_mm_limits(self):
+        limits = original(self)
+        unsupported = _gguf_unsupported_modalities(self.ctx.model_config)
+        if not unsupported:
+            return limits
+        return {
+            modality: limit
+            for modality, limit in limits.items()
+            if modality not in unsupported
+        }
+
+    patched = cached_property(supported_mm_limits)
+    BaseProcessingInfo.supported_mm_limits = patched
+    # Assigning a cached_property after class creation skips __set_name__, which
+    # is what tells it which attribute to cache under.
+    patched.__set_name__(BaseProcessingInfo, "supported_mm_limits")
+    BaseProcessingInfo._gguf_mm_limits_patched = True
+
+
 def _register_omni_diffusion_quantization() -> None:
     try:
         from vllm_omni.quantization import register_quantization_override
@@ -145,4 +193,5 @@ def register() -> None:
         register_config_parser("gguf")(GGUFConfigParser)
     _patch_engine_args()
     _patch_speculator_probe()
+    _patch_mm_limits()
     _patch_diffusers_loader()

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -11,12 +11,14 @@ from .diffusion import (
     get_diffusion_gguf_adapter,
 )
 from .gemma3 import Gemma3GGUFAdapter
+from .muse_glimmer import MuseGlimmerGGUFAdapter
 from .olmoe import OLMoEGGUFAdapter
 from .qwen3_5 import Qwen35GGUFAdapter, Qwen35MtpGGUFAdapter
 from .transformers import TransformersGGUFWeightsAdapter
 
 _ADAPTER_REGISTRY: list[type[BaseGGUFWeightsAdapter]] = [
     Gemma3GGUFAdapter,
+    MuseGlimmerGGUFAdapter,
     OLMoEGGUFAdapter,
     Qwen35GGUFAdapter,
     Qwen35MtpGGUFAdapter,
@@ -45,6 +47,7 @@ __all__ = [
     "Flux2KleinDiffusionGGUFAdapter",
     "GGUFModelFiles",
     "Gemma3GGUFAdapter",
+    "MuseGlimmerGGUFAdapter",
     "OLMoEGGUFAdapter",
     "QwenImageDiffusionGGUFAdapter",
     "Qwen35GGUFAdapter",

--- a/vllm_gguf_plugin/weights_adapter/base.py
+++ b/vllm_gguf_plugin/weights_adapter/base.py
@@ -28,6 +28,14 @@ class BaseGGUFWeightsAdapter(ABC):
     #: model in speculative decoding) and must stay unquantized.
     extra_unquantized_modules: tuple[str, ...] = ()
 
+    #: Modalities this adapter cannot reconstruct from GGUF weights.  Some
+    #: converters fold away information that one modality needs while leaving
+    #: the rest of the model intact; listing it here drops it from the model's
+    #: supported multimodal limits, so requests carrying it are rejected during
+    #: input validation instead of running against weights that cannot
+    #: represent them.
+    UNSUPPORTED_MODALITIES: tuple[str, ...] = ()
+
     @classmethod
     @abstractmethod
     def matches(cls, config: PretrainedConfig) -> bool:

--- a/vllm_gguf_plugin/weights_adapter/muse_glimmer.py
+++ b/vllm_gguf_plugin/weights_adapter/muse_glimmer.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Weight adapter for Muse Glimmer GGUF checkpoints.
+
+Two of the conversions this adapter performs are invisible if you get them
+wrong: the weights load without complaint and the model generates fluent-looking
+but wrong output.  Both are called out where they are implemented.
+
+The first is the Q/K row layout.  The conversion script that produces these GGUF
+files re-lays out the Q and K projections from the half-split ("NEOX") ordering
+that HF checkpoints use into llama.cpp's interleaved ordering.  vLLM's Muse
+Glimmer implementation hardcodes NEOX rotary embeddings, so the adapter has to
+undo that re-layout.
+
+The re-layout only reorders rows of the output dimension; it never changes a
+value.  Because GGUF splits quantized super-blocks along the *input* dimension,
+every output row is a self-contained run of quantized bytes, so the inverse can
+be applied directly to the packed ``qweight`` bytes instead of dequantizing
+first.  ``test_muse_glimmer_gguf.py`` pins that equivalence bit-for-bit.
+
+The second is the norm offset, which applies to the per-layer norms but not to
+the final one -- see :data:`NORM_OFFSET_SUFFIXES`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.logger import init_logger
+from vllm.model_executor.models.utils import WeightsMapper
+
+from ..gguf_files import GGUFModelFiles
+from ..gguf_utils import maybe_patch_hf_config_from_gguf
+from ..weight_utils import get_gguf_tensor_names
+from .base import BaseGGUFWeightsAdapter, GGUFWeight
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+    from vllm.config import ModelConfig
+
+logger = init_logger(__name__)
+
+MUSE_GLIMMER_MODEL_TYPES = ("muse_glimmer", "muse_glimmer_text")
+
+# Neither entry can be looked up in the auto-model mappings: the text-only config
+# is in no mapping at all, and while the multimodal one is registered for
+# image-text-to-text, the config parser only consults the causal-LM mapping.
+# Getting these two crossed does not raise -- pointing ``muse_glimmer`` at the
+# causal-LM class quietly builds a text-only model that loads and generates.
+MUSE_GLIMMER_ARCHITECTURES = {
+    "muse_glimmer": "MuseGlimmerForConditionalGeneration",
+    "muse_glimmer_text": "MuseGlimmerForCausalLM",
+}
+
+
+def interleaved_to_neox_row_index(
+    num_heads: int,
+    head_dim: int,
+    device: torch.device | str = "cpu",
+) -> torch.Tensor:
+    """Row gather index turning llama.cpp interleaved order back into NEOX.
+
+    The forward direction (what the conversion script did) writes NEOX row ``i``
+    to interleaved row ``2i`` for the first half of a head and to ``2i + 1`` for
+    the second half.  Inverting it means gathering the even rows first, then the
+    odd rows, within each head::
+
+        [0, 2, 4, ..., head_dim - 2, 1, 3, 5, ..., head_dim - 1]
+
+    This permutation is **not** self-inverse for ``head_dim >= 8``, so applying
+    the forward helper twice does not undo it.  ``head_dim == 4`` happens to be
+    self-inverse, which makes it a misleading size to test against.
+    """
+    if head_dim % 2:
+        raise ValueError(f"head_dim must be even, got {head_dim}")
+
+    within_head = torch.cat(
+        (
+            torch.arange(0, head_dim, 2, device=device),
+            torch.arange(1, head_dim, 2, device=device),
+        )
+    )
+    head_offsets = torch.arange(num_heads, device=device) * head_dim
+    return (head_offsets[:, None] + within_head[None, :]).reshape(-1)
+
+
+def neox_to_interleaved_row_index(
+    num_heads: int,
+    head_dim: int,
+    device: torch.device | str = "cpu",
+) -> torch.Tensor:
+    """Row gather index for the forward direction, for tests and debugging."""
+    if head_dim % 2:
+        raise ValueError(f"head_dim must be even, got {head_dim}")
+
+    half = head_dim // 2
+    within_head = torch.empty(head_dim, dtype=torch.int64, device=device)
+    within_head[0::2] = torch.arange(0, half, device=device)
+    within_head[1::2] = torch.arange(half, head_dim, device=device)
+    head_offsets = torch.arange(num_heads, device=device) * head_dim
+    return (head_offsets[:, None] + within_head[None, :]).reshape(-1)
+
+
+def undo_rope_interleave(
+    tensor: torch.Tensor,
+    num_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Restore NEOX row order on a Q or K tensor.
+
+    Works on packed ``qweight`` bytes (``[num_rows, row_bytes]`` uint8), on
+    dequantized weights (``[num_rows, input_dim]``) and on 1-D biases alike:
+    all three only need the leading dimension permuted.
+    """
+    num_rows = tensor.shape[0]
+    expected = num_heads * head_dim
+    if num_rows != expected:
+        raise ValueError(
+            f"expected {expected} rows for {num_heads} heads of {head_dim}, "
+            f"got {num_rows}"
+        )
+
+    index = interleaved_to_neox_row_index(num_heads, head_dim, tensor.device)
+    # index_select copies, so the result stays contiguous even though the gather
+    # is non-monotonic; downstream TP sharding and QKV fusion rely on that.
+    return tensor.index_select(0, index)
+
+
+TEXT_LAYER_PREFIX = "model.language_model.layers."
+VISION_LAYER_PREFIX = "model.vision_tower.layers."
+PATCH_EMBEDDING = "model.vision_tower.patch_embedder.patch_embedding.weight"
+
+# llama.cpp's converter folds the ``1 +`` from this architecture's norm into the
+# stored weight, so it has to be taken back out.  Only the per-layer norms carry
+# the offset; the final norm is stored as-is.  Its weights sit close to 1.0, so
+# subtracting from it as well would leave values close to 0 and scale the last
+# hidden state away entirely.  Hence an explicit list of the four per-layer norms
+# rather than a test on the ``norm.weight`` suffix, which the final norm matches
+# too.
+NORM_OFFSET_SUFFIXES = (
+    "input_layernorm.weight",
+    "post_attention_layernorm.weight",
+    "pre_feedforward_layernorm.weight",
+    "post_feedforward_layernorm.weight",
+)
+
+# The Q/K norms in these files are not learned parameters: the converter
+# synthesizes them as constant tensors from the config's scale factor.  vLLM
+# applies that factor itself from the config, so loading them would apply it
+# twice.  Dropping them is what makes the rest of the mapping a bijection onto
+# the HF checkpoint.
+#
+# Skipped before the name map is built rather than mapped to ``None``, so that
+# they do not land in the list of tensors reported as unmapped: that list is for
+# names the mapping failed to cover, and these are left out on purpose.
+SYNTHETIC_QK_NORM_SUBSTRINGS = ("attn_q_norm.", "attn_k_norm.")
+
+# Modules that have to be handed plain weights rather than packed bytes, for two
+# unrelated reasons -- both on the vLLM side, neither fixable from here:
+#
+#   * ``embed_tokens`` is built without forwarding ``quant_config``, so the layer
+#     only ever owns a plain ``weight`` and rejects packed bytes outright ("no
+#     module or parameter named model.embed_tokens.qweight_type").
+#   * the vision tower's linear layers are either plain ``nn.Linear`` or are also
+#     built without ``quant_config``, so they have nowhere to put packed bytes.
+#
+# Unpacking costs roughly 1.9 GB for the embedding and 2.5 GB for the vision
+# tower.  Both shrink back once vLLM forwards ``quant_config`` in those places.
+#
+# Every prefix here is also declared unquantized by
+# :attr:`MuseGlimmerGGUFAdapter.extra_unquantized_modules`.  That is what keeps
+# the two decisions from drifting apart: whichever way vLLM builds these layers,
+# ``get_quant_method`` sees them as unquantized and expects the plain ``weight``
+# this adapter hands over.  Without the declaration, vLLM forwarding
+# ``quant_config`` here would make the layer allocate ``qweight`` buffers that no
+# incoming tensor matches.
+DEQUANTIZED_MODULE_PREFIXES = (
+    "model.language_model.embed_tokens",
+    "model.vision_tower.",
+    "model.vision_adapter.",
+    "model.vision_projection",
+)
+
+_VISION_GGUF_PREFIXES = ("v.", "mm.")
+
+
+def has_vision(config: PretrainedConfig) -> bool:
+    """Whether the vision tower is part of this model.
+
+    Deliberately the same rule vLLM's Muse Glimmer implementation applies, so
+    that the weights this adapter produces and the modules vLLM builds are
+    decided by one predicate rather than two.  Reading it off the directory
+    instead -- taking the vision tower to be present whenever a projector file
+    happens to be resolvable -- decides it a second time, and the two answers
+    disagree as soon as a config turns vision off.
+
+    The shipped ``config.json`` carries no ``has_vision`` key, so the fallback is
+    the usual path; the attribute is there for turning vision off explicitly.
+    """
+    configured = getattr(config, "has_vision", None)
+    if configured is not None:
+        return bool(configured)
+    return hasattr(config, "vision_config")
+
+
+def _module_of(param: str) -> str:
+    return param.rsplit(".", 1)[0] if param.endswith((".weight", ".bias")) else param
+
+
+def dequantized_module_names(mapped_names: Iterable[str]) -> set[str]:
+    """Full-depth module names for every weight :meth:`transform_weights` unpacks.
+
+    Takes names that have already been mapped into vLLM's namespace, so the rule
+    can be tested against a handful of synthetic names.
+
+    Declaring only the prefixes above would read as equivalent and is not.
+    ``is_layer_skipped_gguf`` handles a fused layer by asking whether some
+    declared name *contains* the full path of each shard, so a prefix -- being
+    shorter than the path it is a prefix of -- never matches one.  The vision
+    tower's attention is fused into ``qkv_proj``, and these full paths are what
+    covers it.
+    """
+    return {
+        _module_of(name)
+        for name in mapped_names
+        if name.startswith(DEQUANTIZED_MODULE_PREFIXES)
+    }
+
+
+def dequantize_packed_rows(
+    qweight: torch.Tensor,
+    quant_type: int,
+    dtype: torch.dtype,
+    rows_per_chunk: int = 4096,
+) -> torch.Tensor:
+    """Unpack GGUF bytes straight into *dtype*.
+
+    ``gguf.quants.dequantize`` hands back float32, which for a vocabulary this
+    size is several gigabytes on top of the result.  Rows are self-contained --
+    GGUF blocks never straddle one -- so converting a block of rows at a time
+    keeps the transient down to the block rather than the whole tensor.
+    """
+    from gguf import GGML_QUANT_SIZES, GGMLQuantizationType
+    from gguf.quants import dequantize
+
+    ggml_type = GGMLQuantizationType(quant_type)
+    block_size, type_size = GGML_QUANT_SIZES[ggml_type]
+    num_rows, row_bytes = qweight.shape
+    num_cols = row_bytes // type_size * block_size
+
+    packed = qweight.numpy()
+    out = torch.empty((num_rows, num_cols), dtype=dtype)
+    for start in range(0, num_rows, rows_per_chunk):
+        stop = min(start + rows_per_chunk, num_rows)
+        values = dequantize(packed[start:stop], ggml_type)
+        out[start:stop] = torch.from_numpy(values.reshape(stop - start, num_cols)).to(
+            dtype
+        )
+    return out
+
+
+def reconstruct_patch_embedding(
+    summed: torch.Tensor,
+    patch_temporal: int,
+) -> torch.Tensor:
+    """Undo the converter's sum over the patch embedding's time axis.
+
+    The checkpoint keeps one weight block per time step, laid out with time as
+    the outermost axis of the flattened patch dimension; the converter stores
+    only their sum, so the individual blocks are gone for good.
+
+    Splitting the sum evenly is exact for still images and is also the closest
+    available guess at the original blocks.  The encoder feeds a still image to
+    every time step by expanding the same patch, so the output only ever depends
+    on the sum -- any split reproducing it is equivalent.  And the reference
+    blocks turn out to be near-copies of each other (equal mean magnitude to
+    within 0.1%, correlation 0.99), so half the sum is close to each of them.
+
+    Video feeds distinct frames per time step, which does depend on the blocks
+    individually, and is rejected for that reason.
+    """
+    flat = summed.reshape(summed.shape[0], -1)
+    return flat.div(patch_temporal).repeat(1, patch_temporal)
+
+
+# The vision tower cannot reuse the text substring rules: GGUF calls both
+# projections ``attn_q``, while the checkpoint calls the text one
+# ``self_attn.q_proj`` and the vision one ``attn.q_proj``.  Anchored regexes keep
+# the two apart -- they run before the substring pass, so a rewritten vision name
+# no longer matches any text rule.
+_VISION_BLOCK_LEAVES = {
+    "attn_q": "attn.q_proj",
+    "attn_k": "attn.k_proj",
+    "attn_v": "attn.v_proj",
+    "attn_out": "attn.proj",
+    # Straight, not crossed: GGUF ``ffn_up`` is (8960, 1536), which is ``fc1``.
+    "ffn_up": "mlp.fc1",
+    "ffn_down": "mlp.fc2",
+    # These carry no offset, unlike the text norms -- they are stored as-is, so
+    # they must not appear in NORM_OFFSET_SUFFIXES.
+    "ln1": "norm1",
+    "ln2": "norm2",
+}
+
+
+def build_muse_glimmer_mapper() -> WeightsMapper:
+    orig_to_new_regex: dict[re.Pattern, str | None] = {
+        re.compile(rf"^v\.blk\.(\d+)\.{gguf}\."): (f"{VISION_LAYER_PREFIX}\\1.{hf}.")
+        for gguf, hf in _VISION_BLOCK_LEAVES.items()
+    }
+    orig_to_new_substr: dict[str, str | None] = {
+        "attn_norm.": "input_layernorm.",
+        "post_attention_norm.": "post_attention_layernorm.",
+        "ffn_norm.": "pre_feedforward_layernorm.",
+        "post_ffw_norm.": "post_feedforward_layernorm.",
+        "attn_q.": "self_attn.q_proj.",
+        "attn_k.": "self_attn.k_proj.",
+        "attn_v.": "self_attn.v_proj.",
+        "attn_output.": "self_attn.o_proj.",
+        "attn_gate.": "self_attn.gate_proj.",
+        "ffn_gate.": "mlp.gate_proj.",
+        "ffn_up.": "mlp.up_proj.",
+        "ffn_down.": "mlp.down_proj.",
+    }
+    orig_to_new_prefix: dict[str, str | None] = {
+        "token_embd.": "model.language_model.embed_tokens.",
+        "blk.": TEXT_LAYER_PREFIX,
+        "output_norm.": "model.language_model.norm.",
+        "output.": "lm_head.",
+        "v.patch_embd.": "model.vision_tower.patch_embedder.patch_embedding.",
+        "v.position_embd.": (
+            "model.vision_tower.patch_embedder.position_embedding_table."
+        ),
+        "v.pre_ln.": "model.vision_tower.ln_pre.",
+        "v.post_ln.": "model.vision_tower.ln_post.",
+        # Shapes pin these three down: (4096, 6144), (4096, 4096) and
+        # (6656, 4096) are all distinct and each matches exactly one target.
+        "mm.0.": "model.vision_adapter.fc1.",
+        "mm.1.": "model.vision_adapter.fc2.",
+        "mm.2.": "model.vision_projection.",
+    }
+
+    return WeightsMapper(
+        orig_to_new_regex=orig_to_new_regex,
+        orig_to_new_prefix=orig_to_new_prefix,
+        orig_to_new_substr=orig_to_new_substr,
+    )
+
+
+class MuseGlimmerGGUFAdapter(BaseGGUFWeightsAdapter):
+    """Adapter for Muse Glimmer GGUF models."""
+
+    # Only the sum of the patch embedding's per-time-step blocks survives the
+    # conversion; see reconstruct_patch_embedding. Still images depend on that
+    # sum alone, so they are exact, while video depends on the blocks
+    # individually and would run about 7% off in the one channel that carries
+    # frame-to-frame motion -- wrong in a way that still looks plausible.
+    UNSUPPORTED_MODALITIES = ("video",)
+
+    def __init__(self) -> None:
+        self._name_map: dict[str, str] | None = None
+
+    @classmethod
+    def matches(cls, config) -> bool:
+        return config.model_type in MUSE_GLIMMER_MODEL_TYPES
+
+    @classmethod
+    def architecture(cls, config) -> str | None:
+        return MUSE_GLIMMER_ARCHITECTURES.get(config.model_type)
+
+    def patch_hf_config(
+        self,
+        files: GGUFModelFiles,
+        hf_config: PretrainedConfig,
+    ) -> PretrainedConfig:
+        patched = maybe_patch_hf_config_from_gguf(
+            files.primary_backbone,
+            hf_config,
+            mmproj_path=files.mm_proj,
+        )
+        if has_vision(patched) and files.mm_proj is None:
+            raise RuntimeError(
+                "The vision tower needs the multimodal projector, and no mmproj "
+                f"file could be resolved for {files.primary_backbone}.  "
+                "Requesting one quantization does not bring it along, since the "
+                "projector is quantized separately.  Place *mmproj*.gguf beside "
+                "the backbone, pass model_loader_extra_config={'mm_proj': ...}, "
+                "or set has_vision=false to run text-only.  Continuing without "
+                "it would leave the vision weights unloaded, which text prompts "
+                "would not reveal."
+            )
+        return patched
+
+    def build_name_map(
+        self,
+        files: GGUFModelFiles,
+        model_config: ModelConfig,
+    ) -> dict[str, str]:
+        mapper = build_muse_glimmer_mapper()
+        vision = has_vision(model_config.hf_config)
+
+        name_map: dict[str, str] = {}
+        unmapped: list[str] = []
+        for name in sorted(get_gguf_tensor_names(files.all_files)):
+            if any(substr in name for substr in SYNTHETIC_QK_NORM_SUBSTRINGS):
+                continue
+            # The projector is resolved by the loader from the directory, so it
+            # can turn up even for a config that runs text-only.  Leaving its
+            # tensors out of the map is what keeps them from being loaded.
+            if not vision and name.startswith(_VISION_GGUF_PREFIXES):
+                continue
+            mapped = mapper.apply_list([name])
+            if not mapped or mapped[0] == name:
+                unmapped.append(name)
+            else:
+                name_map[name] = mapped[0]
+
+        if unmapped:
+            logger.warning(
+                "No HF name for %d Muse Glimmer GGUF tensor(s), skipping: %s",
+                len(unmapped),
+                unmapped,
+            )
+        self._name_map = name_map
+        return name_map
+
+    @property
+    def extra_unquantized_modules(self) -> tuple[str, ...]:
+        """Modules this adapter unpacks, which the GGUF stores quantized.
+
+        The loader derives its own list from the tensors a GGUF stores
+        unquantized, which these are not -- they are quantized in the file and
+        dequantized here -- so they have to be declared separately.
+
+        Derived from the name map rather than assigned during
+        :meth:`build_name_map`, so that reading it too early fails loudly.  Were
+        it assigned, a reordering on the loader's side would silently under-
+        declare, and an under-declared fused layer allocates packed buffers that
+        no incoming tensor matches.
+        """
+        if self._name_map is None:
+            raise RuntimeError(
+                "extra_unquantized_modules was read before build_name_map; the "
+                "declaration is derived from the name map"
+            )
+        # Both forms are needed.  The full paths are what a fused layer matches
+        # against; the prefixes cover the layers vLLM's own mapper renames on the
+        # way in (``attn.proj`` becomes ``attn.o_proj``, and a full path recorded
+        # under the old name stops matching).
+        return tuple(
+            sorted(
+                dequantized_module_names(self._name_map.values())
+                | set(DEQUANTIZED_MODULE_PREFIXES)
+            )
+        )
+
+    def _rope_layout(
+        self,
+        name: str,
+        config: PretrainedConfig,
+    ) -> tuple[int, int] | None:
+        """``(num_heads, head_dim)`` to un-interleave *name* with, else ``None``.
+
+        Only Q and K are rotated, so only they were re-laid out.  V shares their
+        shape and quantization, so permuting it as well is not caught by any
+        shape check -- it just corrupts every value it touches.
+
+        The text and vision towers have to be told apart before the projection
+        name is inspected, because the text module ``self_attn.q_proj`` also ends
+        with the vision module's ``attn.q_proj``.
+        """
+        # ``.qweight_type`` is a scalar tag rather than a weight; it shares the
+        # module prefix, so match on the payload suffixes instead.
+        if not name.endswith((".qweight", ".weight", ".bias")):
+            return None
+        module = name.rsplit(".", 1)[0]
+
+        if name.startswith(TEXT_LAYER_PREFIX):
+            text_config = config.get_text_config()
+            if module.endswith("self_attn.q_proj"):
+                return text_config.num_attention_heads, text_config.head_dim
+            if module.endswith("self_attn.k_proj"):
+                return text_config.num_key_value_heads, text_config.head_dim
+            return None
+
+        if name.startswith(VISION_LAYER_PREFIX):
+            if not module.endswith(("attn.q_proj", "attn.k_proj")):
+                return None
+            # The vision tower is not grouped-query, so Q and K share a count.
+            vision_config = config.vision_config
+            num_heads = vision_config.num_attention_heads
+            return num_heads, vision_config.hidden_size // num_heads
+
+        return None
+
+    def transform_weights(
+        self,
+        weights: Iterable[GGUFWeight],
+        model_config: ModelConfig,
+    ) -> Iterable[GGUFWeight]:
+        """Transform mapped GGUF weights into HF-style weights."""
+        config = model_config.hf_config
+        dtype = model_config.dtype
+
+        # The iterator emits a module's ``qweight_type`` immediately before its
+        # ``qweight``, so a single slot is enough to rejoin the two.
+        quant_types: dict[str, int] = {}
+        for name, weight in weights:
+            module, _, leaf = name.rpartition(".")
+            if leaf in ("qweight", "qweight_type") and module.startswith(
+                DEQUANTIZED_MODULE_PREFIXES
+            ):
+                if leaf == "qweight_type":
+                    quant_types[module] = int(weight.item())
+                    continue
+                name = f"{module}.weight"
+                weight = dequantize_packed_rows(weight, quant_types.pop(module), dtype)
+
+            if name == PATCH_EMBEDDING:
+                weight = reconstruct_patch_embedding(
+                    weight, config.vision_config.patch_temporal
+                )
+            elif name.endswith(NORM_OFFSET_SUFFIXES):
+                weight = weight - 1
+            elif (layout := self._rope_layout(name, config)) is not None:
+                weight = undo_rope_interleave(weight, *layout)
+            yield name, weight


### PR DESCRIPTION
## Summary

Adds a weights adapter for Muse Glimmer GGUF checkpoints, so a Q4_K_XL backbone plus its separately quantized Q4_K_M projector loads and serves text and image prompts. Video is rejected rather than served, for the reason below.

Converting this architecture to GGUF is not a pure requantization. Four things change on the way in, and each one loads without complaint and produces fluent but wrong output if it is not undone. The adapter reverses them; each is explained where it is implemented.

Rebased onto the current `WeightsAdapter` interface (#97); the branch is now a single commit.

## The four conversions

1. **Q/K row layout.** The converter re-lays out the Q and K projections from the half-split ("NEOX") row order HF checkpoints use into llama.cpp's interleaved order. vLLM's implementation hardcodes NEOX rotary embeddings, so the adapter inverts it — directly on the packed `qweight` bytes, since GGUF splits super-blocks along the input dimension and so leaves each output row a self-contained run of bytes. A test pins that against the dequantized path bit-for-bit.
2. **Per-layer norm offset.** llama.cpp folds this architecture's `1 +` into the stored weight, so it is subtracted back out — from the four per-layer norms only, as the final norm and the vision tower's norms are stored as-is.
3. **Synthetic Q/K norms.** The converter fabricates these from the config's scale factor rather than storing learned ones. vLLM applies that factor itself, so they are dropped instead of applied twice.
4. **Vision patch embedding.** The converter stores only the sum of the per-time-step blocks. Splitting it evenly is exact for still images, because the encoder expands one patch to every time step and the output depends on the sum alone.

Video is the exception. It feeds distinct frames per time step, so it does depend on the individual blocks, and runs about 7% off in the channel carrying motion — wrong in a way that still looks plausible. Adapters can now declare
`UNSUPPORTED_MODALITIES`, and the plugin drops those from the model's supported multimodal limits, so video requests fail vLLM's normal input validation.

## Supporting changes

* **The adapter declares its own architecture.** `architecture()` returns the class name for both the multimodal and the text-only model type, and the config parser consults it before the causal-LM mapping. Vision-language models are not in that mapping, so this config was rejected before any weight was touched.
* **Vision is decided by the config, not by the directory.** The projector is loaded only when `has_vision(config)` holds — the same predicate vLLM's own implementation uses, so the weights produced and the modules built are decided
once rather than twice. Loading the projector merely because an mmproj file sits next to the backbone disagrees as soon as a config turns vision off, and leaves every vision tensor unloaded with nothing in a text prompt to reveal it. Vision enabled with no projector present now fails with an explanation.
* **`embed_tokens` and the vision tower are handed plain weights**, as vLLM builds them without forwarding `quant_config` and they have nowhere to put packed bytes. They are declared unquantized as both full paths and prefixes: fused layers match on the former, and layers vLLM's mapper renames on the way in need the latter.

## Testing

* **81 targeted tests** across `test_muse_glimmer_gguf.py`, `test_plugin.py` and `test_multimodal_gguf.py`, all synthetic, so the conversions are covered without needing the 30B weights in CI. They pin the packed-bytes permutation
against the dequantized path, the norm suffix list including the final norm and the vision norms, the Q/K-norm discard, text/vision name separation, the patch-embedding reconstruction, the unquantized declarations for both fused and
renamed layers, and the vision gate across the combinations of `has_vision`, projector presence and config type.
* **End-to-end against the real 30B**, GGUF versus HF BF16 on images: passes. `pytest tests/test_multimodal_gguf.py::test_muse_glimmer_mm_gguf -m slow`
* Also checked against the real weights outside CI: the name map is an exact bijection onto the checkpoint's 1436 parameters (1540 GGUF tensors less the 104 discarded Q/K norms, nothing unmapped); dequantizing the adapter's output reproduces the BF16 weights for the permuted and unpermuted projections alike; text and image prompts serve correctly under `tensor_parallel_size=2`, which is what the permutation's contiguous copy is for; and a `has_vision=false` config serves text with every vision tensor left unloaded.

### Note on the existing suite

The fast suite has some pre-existing failures unrelated to this change: `test_kernels.py` asks for more LDS than gfx942 has, and `test_gguf_generation.py` pulls a gated Hugging Face repo.

## Known limitations

* **Video is not supported** and is rejected at input validation, for the reason above.
* **The projector is not fetched automatically.** Requesting one quantization does not bring the mmproj along, since it is quantized separately; it has to be in the same directory. Loading fails with an explanation rather than silently running
with an unloaded vision tower. Auto-fetching touches the path shared with Gemma 3, so it is left for a follow-up.
* **Speculative decoding with GGUF** is still blocked before any adapter is consulted. A draft passed as a single GGUF file has its config resolved from the file's parent directory, which holds no `config.json`, and there is no per-draft
equivalent of the target's `hf_config_path`, so `SpeculativeConfig` fails validation with `Unrecognized model ... Should have a model_type key in its config.json`. This affects all GGUF models rather than this one, so a separate follow-up PR will implement it.