### PR TITLE
[Models] Serve Qwen3.5/3.6/3.8 text-only GGUF without an mm_proj

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -27,6 +27,8 @@ import vllm_gguf_plugin.quantization as gguf_quantization
 import vllm_gguf_plugin.quantization.params as gguf_params_module
 from vllm_gguf_plugin import OOTGGUFConfig, OOTGGUFModelLoader, register
 from vllm_gguf_plugin.config_parser import GGUFConfigParser
+from vllm_gguf_plugin.gguf_context import set_gguf_request
+from vllm_gguf_plugin.gguf_utils import is_text_only_gguf
 from vllm_gguf_plugin.quantization import (
     GGUFUninitializedParameter,
     GGUFWeightParameter,
@@ -219,6 +221,82 @@ def test_gguf_config_parser_uses_parent_dir_for_local_file(tmp_path, monkeypatch
     assert calls["trust_remote_code"] is False
     assert config_dict["norm_topk_prob"] is True
     assert config.architectures == ["Qwen3MoeForCausalLM"]
+
+
+def test_gguf_config_parser_builds_text_only_architecture(tmp_path, monkeypatch):
+    """A backbone with no vision tensors is built as its text architecture."""
+    gguf_path = tmp_path / "Qwen3.8-27B-Q4_K_M.gguf"
+    gguf_path.write_bytes(b"GGUF")
+
+    text_config = PretrainedConfig(model_type="qwen3_5_text")
+    multimodal_config = PretrainedConfig(model_type="qwen3_5")
+    multimodal_config.vision_config = PretrainedConfig(model_type="qwen3_5_vision")
+    monkeypatch.setattr(
+        type(multimodal_config), "get_text_config", lambda self, **kw: text_config
+    )
+
+    monkeypatch.setattr(
+        gguf_config_parser_module.HFConfigParser,
+        "parse",
+        lambda self, model, trust_remote_code, revision=None, code_revision=None, **kw: (
+            {},
+            multimodal_config,
+        ),
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda model, config: config,
+    )
+    set_gguf_request(str(gguf_path), None)
+    try:
+        _, config = GGUFConfigParser().parse(gguf_path, trust_remote_code=False)
+    finally:
+        set_gguf_request(None, None)
+
+    assert config is text_config
+    assert config.architectures == ["Qwen3_5ForCausalLM"]
+
+
+def test_gguf_config_parser_keeps_multimodal_with_explicit_mm_proj(
+    tmp_path, monkeypatch
+):
+    """An explicitly configured projector keeps the multimodal architecture."""
+    gguf_path = tmp_path / "Qwen3.8-27B-Q4_K_M.gguf"
+    gguf_path.write_bytes(b"GGUF")
+
+    multimodal_config = PretrainedConfig(model_type="qwen3_5")
+    multimodal_config.vision_config = PretrainedConfig(model_type="qwen3_5_vision")
+
+    monkeypatch.setattr(
+        gguf_config_parser_module.HFConfigParser,
+        "parse",
+        lambda self, model, trust_remote_code, revision=None, code_revision=None, **kw: (
+            {},
+            multimodal_config,
+        ),
+    )
+    monkeypatch.setattr(
+        gguf_config_parser_module,
+        "maybe_patch_hf_config_from_gguf",
+        lambda model, config: config,
+    )
+    set_gguf_request(str(gguf_path), str(tmp_path / "mmproj.gguf"))
+    try:
+        _, config = GGUFConfigParser().parse(gguf_path, trust_remote_code=False)
+    finally:
+        set_gguf_request(None, None)
+
+    assert config.architectures == ["Qwen3_5ForConditionalGeneration"]
+
+
+def test_is_text_only_gguf_detects_mmproj_sibling(tmp_path):
+    gguf_path = tmp_path / "model.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    assert is_text_only_gguf(gguf_path) is True
+
+    (tmp_path / "mmproj-F16.gguf").write_bytes(b"GGUF")
+    assert is_text_only_gguf(gguf_path) is False
 
 
 def test_register_sets_engine_args_for_gguf_model(monkeypatch):

--- a/vllm_gguf_plugin/config_parser.py
+++ b/vllm_gguf_plugin/config_parser.py
@@ -11,9 +11,11 @@ from .gguf_utils import (
     check_gguf_file,
     is_gguf,
     is_remote_gguf,
+    is_text_only_gguf,
     maybe_patch_hf_config_from_gguf,
     split_remote_gguf,
 )
+from .gguf_context import get_explicit_mm_proj, get_gguf_weights
 from .weights_adapter import get_adapter_architecture
 
 
@@ -40,7 +42,9 @@ class GGUFConfigParser(ConfigParserBase):
             config_dict["norm_topk_prob"] = True
             config.update({"norm_topk_prob": True})
 
-        architecture = get_adapter_architecture(config)
+        weights_reference = get_gguf_weights() or original_model
+        text_only = is_text_only_gguf(weights_reference, get_explicit_mm_proj())
+        architecture = get_adapter_architecture(config, text_only)
         if (
             architecture is None
             and config.model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
@@ -48,6 +52,14 @@ class GGUFConfigParser(ConfigParserBase):
             architecture = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
         if architecture is None:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
+
+        if text_only:
+            text_config = config.get_text_config()
+            if text_config is not config:
+                # A multimodal HF config for a backbone with no vision tower:
+                # keep only the text half so the causal LM is built from it.
+                config = text_config
+                config_dict = config.to_dict()
 
         config_dict["architectures"] = [architecture]
         config.update({"architectures": [architecture]})

--- a/vllm_gguf_plugin/gguf_context.py
+++ b/vllm_gguf_plugin/gguf_context.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Share GGUF request details with the config parser.
+
+``EngineArgs.create_model_config`` rewrites ``model`` to the HF config source
+and moves the GGUF reference to ``model_weights``, so by the time the config
+parser runs it no longer sees the weights it is parsing a config for. The
+parser also decides the model architecture before any model loader exists, so
+it cannot read ``model_loader_extra_config`` either. Both are recorded here
+while the engine args are resolved.
+"""
+
+_explicit_mm_proj: object | None = None
+_gguf_weights: str | None = None
+
+
+def set_gguf_request(weights: str | None, mm_proj: object | None) -> None:
+    global _explicit_mm_proj, _gguf_weights
+    _gguf_weights = weights
+    _explicit_mm_proj = mm_proj
+
+
+def get_explicit_mm_proj() -> object | None:
+    return _explicit_mm_proj
+
+
+def get_gguf_weights() -> str | None:
+    return _gguf_weights

--- a/vllm_gguf_plugin/gguf_utils.py
+++ b/vllm_gguf_plugin/gguf_utils.py
@@ -241,6 +241,37 @@ def detect_gguf_multimodal(model: str) -> Path | None:
         return None
 
 
+def gguf_has_vision_tensors(model_path: str | PathLike) -> bool:
+    """Whether a GGUF backbone carries vision-tower tensors (``v.``/``mm.``)."""
+    if not check_gguf_file(model_path):
+        return False
+    try:
+        reader = gguf.GGUFReader(str(model_path))
+    except Exception as e:
+        # Detection must not fail the run; a file that cannot be read here
+        # raises a proper error later when its weights are loaded.
+        logger.debug("Error reading GGUF file %s: %s", model_path, e)
+        return False
+    return any(tensor.name.startswith(("v.", "mm.")) for tensor in reader.tensors)
+
+
+def is_text_only_gguf(model: str | PathLike, explicit_mm_proj: object = None) -> bool:
+    """Whether *model* can only ever be served as a text model.
+
+    A local backbone with no vision tensors, no ``*mmproj*.gguf`` sibling and no
+    explicitly configured projector can never gain one later (the loader only
+    downloads a projector for ``repo_id:quant_type`` references), so the model
+    must be built from the text config instead of the multimodal one.
+    """
+    if explicit_mm_proj is not None:
+        return False
+    if not check_gguf_file(model):
+        return False
+    if detect_gguf_multimodal(str(model)) is not None:
+        return False
+    return not gguf_has_vision_tensors(model)
+
+
 def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | None":
     """Extract vision config parameters from mmproj.gguf metadata.
 

--- a/vllm_gguf_plugin/plugin.py
+++ b/vllm_gguf_plugin/plugin.py
@@ -16,6 +16,7 @@ from vllm.model_executor.model_loader import (
 from vllm.transformers_utils.config import get_config_parser, register_config_parser
 
 from .config_parser import GGUFConfigParser
+from .gguf_context import set_gguf_request
 from .gguf_utils import check_gguf_file, is_gguf, is_remote_gguf, split_remote_gguf
 from .loader import GGUFModelLoader
 from .quantization import DiffusionGGUFConfig, GGUFConfig
@@ -58,6 +59,13 @@ def _patch_engine_args() -> None:
     def create_model_config(self, *args, **kwargs):
         if _is_gguf_reference(self.model):
             gguf_model = self.model
+            extra_config = self.model_loader_extra_config or {}
+            set_gguf_request(
+                gguf_model,
+                extra_config.get("mm_proj")
+                if isinstance(extra_config, dict)
+                else None,
+            )
             if self.quantization is None:
                 self.quantization = "gguf"
             if self.load_format == "auto":

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -31,11 +31,11 @@ def get_weights_adapter(config) -> BaseGGUFWeightsAdapter:
     return TransformersGGUFWeightsAdapter()
 
 
-def get_adapter_architecture(config) -> str | None:
+def get_adapter_architecture(config, text_only: bool = False) -> str | None:
     """Return an architecture override declared by a registered adapter."""
     for cls in _ADAPTER_REGISTRY:
         if cls.matches(config):
-            return cls.architecture(config)
+            return cls.architecture(config, text_only)
     return None
 
 

--- a/vllm_gguf_plugin/weights_adapter/base.py
+++ b/vllm_gguf_plugin/weights_adapter/base.py
@@ -34,9 +34,15 @@ class BaseGGUFWeightsAdapter(ABC):
         """Return whether this adapter supports *config*."""
 
     @classmethod
-    def architecture(cls, config: PretrainedConfig) -> str | None:
-        """Return an architecture override required before model loading."""
-        del config
+    def architecture(
+        cls, config: PretrainedConfig, text_only: bool = False
+    ) -> str | None:
+        """Return an architecture override required before model loading.
+
+        *text_only* is set when the GGUF files can only produce a text model,
+        so a multimodal HF config must be built as its text architecture.
+        """
+        del config, text_only
         return None
 
     @abstractmethod

--- a/vllm_gguf_plugin/weights_adapter/qwen3_5.py
+++ b/vllm_gguf_plugin/weights_adapter/qwen3_5.py
@@ -15,7 +15,7 @@ from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5Config
 from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeConfig
 
 from ..gguf_files import GGUFModelFiles
-from ..gguf_utils import maybe_patch_hf_config_from_gguf
+from ..gguf_utils import gguf_has_vision_tensors, maybe_patch_hf_config_from_gguf
 from ..quantization.layout import GGUFHeadTilingLayout, GGUFLinearLayout
 from ..weight_utils import get_gguf_tensor_names, split_stacked_experts
 from .base import BaseGGUFWeightsAdapter, GGUFWeight
@@ -40,6 +40,15 @@ QWEN35_ARCHITECTURES = {
     "qwen3_5_text": "Qwen3_5ForConditionalGeneration",
     "qwen3_5_moe": "Qwen3_5MoeForConditionalGeneration",
     "qwen3_5_moe_text": "Qwen3_5MoeForConditionalGeneration",
+}
+
+#: Used when the GGUF files carry no vision tower, so the model is built from
+#: the text config as a plain causal LM.
+QWEN35_TEXT_ARCHITECTURES = {
+    "qwen3_5": "Qwen3_5ForCausalLM",
+    "qwen3_5_text": "Qwen3_5ForCausalLM",
+    "qwen3_5_moe": "Qwen3_5MoeForCausalLM",
+    "qwen3_5_moe_text": "Qwen3_5MoeForCausalLM",
 }
 
 QWEN35_ATTN_SUBSTR: dict[str, str] = {
@@ -190,8 +199,9 @@ class Qwen35GGUFAdapter(BaseGGUFWeightsAdapter):
         return config.model_type in QWEN35_MODEL_TYPES
 
     @classmethod
-    def architecture(cls, config) -> str | None:
-        return QWEN35_ARCHITECTURES.get(config.model_type)
+    def architecture(cls, config, text_only: bool = False) -> str | None:
+        table = QWEN35_TEXT_ARCHITECTURES if text_only else QWEN35_ARCHITECTURES
+        return table.get(config.model_type)
 
     def patch_hf_config(
         self,
@@ -199,7 +209,10 @@ class Qwen35GGUFAdapter(BaseGGUFWeightsAdapter):
         hf_config: PretrainedConfig,
     ) -> PretrainedConfig:
         model_type = hf_config.model_type
-        architecture = QWEN35_ARCHITECTURES[model_type]
+        text_only = files.mm_proj is None
+        architecture = (
+            QWEN35_TEXT_ARCHITECTURES if text_only else QWEN35_ARCHITECTURES
+        )[model_type]
         patched = maybe_patch_hf_config_from_gguf(
             files.primary_backbone,
             hf_config,
@@ -208,11 +221,22 @@ class Qwen35GGUFAdapter(BaseGGUFWeightsAdapter):
         has_vision = getattr(patched, "vision_config", None) is not None
 
         if has_vision and files.mm_proj is None:
-            raise RuntimeError(
-                "Could not find mm_proj for multimodal Qwen3.5/3.6 GGUF. "
-                "Place *mmproj*.gguf beside the backbone or pass "
-                "model_loader_extra_config={'mm_proj': ...}."
+            if gguf_has_vision_tensors(files.primary_backbone):
+                raise RuntimeError(
+                    "Could not find mm_proj for multimodal Qwen3.5/3.6 GGUF. "
+                    "Place *mmproj*.gguf beside the backbone or pass "
+                    "model_loader_extra_config={'mm_proj': ...}."
+                )
+            # Text-only backbone served against a multimodal HF config: drop
+            # the vision half instead of demanding a projector that would
+            # never be used.
+            logger.info(
+                "No vision tensors and no mm_proj for %s; "
+                "serving it as text-only %s.",
+                files.primary_backbone,
+                architecture,
             )
+            patched = patched.get_text_config()
 
         if files.mm_proj is not None and not has_vision:
             config_cls = (


### PR DESCRIPTION
Qwen3.5-family GGUF backbones are commonly published without a vision tower, but their HF configs are the multimodal composite ones, so the adapter demanded an *mmproj*.gguf that would never be used and refused to start otherwise.

Detect a text-only backbone (no vision tensors, no projector sibling and no explicitly configured one) and build it as its text architecture (Qwen3_5ForCausalLM / Qwen3_5MoeForCausalLM) from the config's text half. The architecture is chosen in the config parser, which runs before any model loader exists, so EngineArgs now records the GGUF reference and the explicit mm_proj for it.

Multimodal loads are unchanged: a projector - detected or configured - still selects the ConditionalGeneration architecture.

Tested on an RTX 3090 with Qwen3.8-27B (dense), Qwen3.6-35B-A3B (MoE), Qwen3.5-9B (single file and 3-way split), all Q4_K_M/Q4_K_XL.