### PR TITLE
Gemma4 gguf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ starting points:
 | Text | Gemma 3 | Q4_0 |
 | Text | OLMoE | Q4_0 |
 | Vision-language | Gemma 3 | Q4_0 backbone with F16 projector |
+| Vision-language | Gemma 4 | Q4_K_M backbone with BF16 projector |
 | Vision-language | Qwen 3.5 | Q4_K_M backbone with BF16 projector |
 | Vision-language | Qwen 3.6 | UD-IQ2_XXS backbone with BF16 projector |
 | Image generation | Z-Image-Turbo | Q4_0 |

--- a/tests/test_gemma4_adapter.py
+++ b/tests/test_gemma4_adapter.py
@@ -19,6 +19,11 @@ def test_gemma4_name_mapping():
     assert Gemma4GGUFAdapter.map_name("v.position_embd.weight") == (
         "model.vision_tower.patch_embedder.position_embedding_table"
     )
+    assert Gemma4GGUFAdapter.map_name("v.std_bias") == ("model.vision_tower.std_bias")
+    assert Gemma4GGUFAdapter.map_name("v.std_scale") == ("model.vision_tower.std_scale")
+    assert Gemma4GGUFAdapter.map_name("mm.input_projection.weight") == (
+        "model.embed_vision.embedding_projection.weight"
+    )
     assert Gemma4GGUFAdapter.map_name("rope_freqs.weight") is None
 
 

--- a/tests/test_gemma4_adapter.py
+++ b/tests/test_gemma4_adapter.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm_gguf_plugin.weights_adapter.gemma4 import Gemma4GGUFAdapter
+
+
+def test_gemma4_name_mapping():
+    assert Gemma4GGUFAdapter.map_name("blk.2.ffn_gate_inp.scale") == (
+        "model.language_model.layers.2.router.scale"
+    )
+    assert Gemma4GGUFAdapter.map_name("blk.2.layer_output_scale.weight") == (
+        "model.language_model.layers.2.layer_scalar"
+    )
+    assert Gemma4GGUFAdapter.map_name("v.blk.3.attn_q.weight") == (
+        "model.vision_tower.encoder.layers.3.self_attn.q_proj.linear.weight"
+    )
+    assert Gemma4GGUFAdapter.map_name("v.position_embd.weight") == (
+        "model.vision_tower.patch_embedder.position_embedding_table"
+    )
+    assert Gemma4GGUFAdapter.map_name("rope_freqs.weight") is None
+
+
+def test_gemma4_splits_packed_gate_up_experts():
+    weight = torch.arange(16).reshape(2, 4, 2)
+    name = "model.language_model.layers.0.experts.0.gate_up_proj.qweight"
+
+    mapped = list(Gemma4GGUFAdapter._split_expert_weights(name, weight))
+
+    assert [item[0] for item in mapped] == [
+        "model.language_model.layers.0.experts.0.gate_proj.qweight",
+        "model.language_model.layers.0.experts.0.up_proj.qweight",
+        "model.language_model.layers.0.experts.1.gate_proj.qweight",
+        "model.language_model.layers.0.experts.1.up_proj.qweight",
+    ]
+    assert torch.equal(mapped[0][1], weight[0, :2])
+    assert torch.equal(mapped[1][1], weight[0, 2:])

--- a/tests/test_multimodal_gguf.py
+++ b/tests/test_multimodal_gguf.py
@@ -22,9 +22,12 @@ from vllm import LLM, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.multimodal.image import rescale_image_size
 
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
 MAX_TOKENS = 32
+# Transformers produces NaN logits after Gemma 4's first cached decode step on ROCm.
+GEMMA4_MAX_TOKENS = 1
 NUM_LOGPROBS = 10
 GPU_MEMORY_UTILIZATION = 0.8
 
@@ -39,6 +42,7 @@ class GGUFMMTestConfig(NamedTuple):
     max_model_len: int = 4096
     marks: list[MarkDecorator] = []
     mm_processor_kwargs: dict[str, Any] = {}
+    image_size_factors: tuple[float, ...] = (0.25, 0.5, 1.0)
 
     @property
     def gguf_model(self) -> str:
@@ -94,7 +98,28 @@ GEMMA3_CONFIG_PAN_AND_SCAN = GGUFMMTestConfig(
     mm_processor_kwargs={"do_pan_and_scan": True},
 )
 
-MODELS_TO_TEST = [GEMMA3_CONFIG, GEMMA3_CONFIG_PAN_AND_SCAN]
+_GEMMA4_PROMPTS = [
+    (
+        "<bos><|turn>user\n"
+        "<|image|>What's the content in the center of the image?<turn|>\n"
+        "<|turn>model\n<|channel>thought\n<channel|>"
+    ),
+]
+
+GEMMA4_CONFIG = GGUFMMTestConfig(
+    original_model="google/gemma-4-26B-A4B-it",
+    gguf_repo="unsloth/gemma-4-26B-A4B-it-GGUF",
+    gguf_backbone="gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
+    gguf_mmproj="mmproj-BF16.gguf",
+    prompt=[_GEMMA4_PROMPTS[0]],
+    image_names=[_GEMMA3_IMAGE_NAMES[0]],
+    max_model_len=4096,
+    marks=[pytest.mark.slow],
+    mm_processor_kwargs={},
+    image_size_factors=(0.25,),
+)
+
+GEMMA3_MODELS_TO_TEST = [GEMMA3_CONFIG, GEMMA3_CONFIG_PAN_AND_SCAN]
 
 
 def _vllm_generate_greedy_logprobs(
@@ -261,11 +286,10 @@ def run_multimodal_gguf_test(
     num_logprobs: int,
 ) -> None:
     images = [ImageAsset(name).pil_image for name in model.image_names]
-    size_factors = [0.25, 0.5, 1.0]
     inputs_per_image = [
         (
-            [prompt for _ in size_factors],
-            [rescale_image_size(image, factor) for factor in size_factors],
+            [prompt for _ in model.image_size_factors],
+            [rescale_image_size(image, factor) for factor in model.image_size_factors],
         )
         for image, prompt in zip(images, model.prompt)
     ]
@@ -315,7 +339,7 @@ def run_multimodal_gguf_test(
     "model",
     [
         pytest.param(test_config, marks=test_config.marks)
-        for test_config in MODELS_TO_TEST
+        for test_config in GEMMA3_MODELS_TO_TEST
     ],
 )
 @pytest.mark.parametrize("dtype", ["bfloat16"])
@@ -328,3 +352,17 @@ def test_gemma3_mm_gguf(
     num_logprobs: int,
 ) -> None:
     run_multimodal_gguf_test(model, dtype, max_tokens, num_logprobs)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for multimodal GGUF tests.",
+)
+@pytest.mark.slow
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+@pytest.mark.parametrize("num_logprobs", [NUM_LOGPROBS])
+def test_gemma4_mm_gguf(
+    dtype: str,
+    num_logprobs: int,
+) -> None:
+    run_multimodal_gguf_test(GEMMA4_CONFIG, dtype, GEMMA4_MAX_TOKENS, num_logprobs)

--- a/vllm_gguf_plugin/weights_adapter/__init__.py
+++ b/vllm_gguf_plugin/weights_adapter/__init__.py
@@ -11,10 +11,12 @@ from .diffusion import (
     get_diffusion_gguf_adapter,
 )
 from .gemma3 import Gemma3GGUFAdapter
+from .gemma4 import Gemma4GGUFAdapter
 from .olmoe import OLMoEGGUFAdapter
 
 _ADAPTER_REGISTRY: list[type[GGUFWeightsAdapter]] = [
     Gemma3GGUFAdapter,
+    Gemma4GGUFAdapter,
     OLMoEGGUFAdapter,
 ]
 
@@ -33,6 +35,7 @@ __all__ = [
     "Flux2KleinDiffusionGGUFAdapter",
     "GGUFWeightsAdapter",
     "Gemma3GGUFAdapter",
+    "Gemma4GGUFAdapter",
     "OLMoEGGUFAdapter",
     "QwenImageDiffusionGGUFAdapter",
     "ZImageDiffusionGGUFAdapter",

--- a/vllm_gguf_plugin/weights_adapter/gemma4.py
+++ b/vllm_gguf_plugin/weights_adapter/gemma4.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+import torch
+
+from ..gguf_utils import detect_gguf_multimodal, maybe_patch_hf_config_from_gguf
+from ..weight_utils import (
+    get_gguf_unquantized_params,
+    gguf_quant_weights_iterator_multi,
+)
+from .base import BaseGGUFWeightsAdapter, GGUFLoadSpec
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+    from vllm.config import ModelConfig
+
+
+class Gemma4GGUFAdapter(BaseGGUFWeightsAdapter):
+    """Adapter for Gemma 4 text and multimodal GGUF models."""
+
+    load_spec = None
+
+    @classmethod
+    def matches(cls, config) -> bool:
+        return config.model_type == "gemma4"
+
+    def patch_hf_config(self, model_path: str, hf_config: PretrainedConfig):
+        return maybe_patch_hf_config_from_gguf(model_path, hf_config)
+
+    @staticmethod
+    def _map_text_name(name: str) -> str | None:
+        top_level = {
+            "token_embd": "model.language_model.embed_tokens",
+            "output_norm": "model.language_model.norm",
+            "output": "lm_head",
+        }
+        for gguf_prefix, hf_prefix in top_level.items():
+            if name == gguf_prefix or name.startswith(f"{gguf_prefix}."):
+                return hf_prefix + name.removeprefix(gguf_prefix)
+
+        match = re.fullmatch(r"blk\.(\d+)\.(.+)", name)
+        if match is None:
+            return None
+        layer_idx, suffix = match.groups()
+        layer = f"model.language_model.layers.{layer_idx}"
+        suffix_map = {
+            "attn_q": "self_attn.q_proj",
+            "attn_k": "self_attn.k_proj",
+            "attn_v": "self_attn.v_proj",
+            "attn_output": "self_attn.o_proj",
+            "attn_q_norm": "self_attn.q_norm",
+            "attn_k_norm": "self_attn.k_norm",
+            "attn_norm": "input_layernorm",
+            "post_attention_norm": "post_attention_layernorm",
+            "ffn_norm": "pre_feedforward_layernorm",
+            "post_ffw_norm": "post_feedforward_layernorm",
+            "post_ffw_norm_1": "post_feedforward_layernorm_1",
+            "post_ffw_norm_2": "post_feedforward_layernorm_2",
+            "pre_ffw_norm_2": "pre_feedforward_layernorm_2",
+            "ffn_gate": "mlp.gate_proj",
+            "ffn_up": "mlp.up_proj",
+            "ffn_down": "mlp.down_proj",
+            "ffn_gate_inp": "router.proj",
+            "ffn_gate_inp.scale": "router.scale",
+            "ffn_down_exps.scale": "router.per_expert_scale",
+            "layer_output_scale": "layer_scalar",
+            "layer_output_scale.weight": "layer_scalar",
+            "ffn_gate_up_exps": "experts.0.gate_up_proj",
+            "ffn_down_exps": "experts.0.down_proj",
+        }
+        for gguf_suffix, hf_suffix in sorted(
+            suffix_map.items(), key=lambda item: len(item[0]), reverse=True
+        ):
+            if suffix == gguf_suffix or suffix.startswith(f"{gguf_suffix}."):
+                return layer + "." + hf_suffix + suffix.removeprefix(gguf_suffix)
+        return None
+
+    @staticmethod
+    def _map_vision_name(name: str) -> str | None:
+        if name == "v.position_embd.weight":
+            return "model.vision_tower.patch_embedder.position_embedding_table"
+        direct = {
+            "v.std_bias": "model.vision_tower.std_bias",
+            "v.std_scale": "model.vision_tower.std_scale",
+            "v.patch_embd": "model.vision_tower.patch_embedder.input_proj",
+            "mm.input_projection": "model.embed_vision.embedding_projection",
+        }
+        for gguf_prefix, hf_prefix in direct.items():
+            if name == gguf_prefix or name.startswith(f"{gguf_prefix}."):
+                return hf_prefix + name.removeprefix(gguf_prefix)
+
+        match = re.fullmatch(r"v\.blk\.(\d+)\.(.+)", name)
+        if match is None:
+            return None
+        layer_idx, suffix = match.groups()
+        layer = f"model.vision_tower.encoder.layers.{layer_idx}"
+        suffix_map = {
+            "attn_q": "self_attn.q_proj.linear",
+            "attn_k": "self_attn.k_proj.linear",
+            "attn_v": "self_attn.v_proj.linear",
+            "attn_out": "self_attn.o_proj.linear",
+            "attn_q_norm": "self_attn.q_norm",
+            "attn_k_norm": "self_attn.k_norm",
+            "ffn_gate": "mlp.gate_proj.linear",
+            "ffn_up": "mlp.up_proj.linear",
+            "ffn_down": "mlp.down_proj.linear",
+            "ln1": "input_layernorm",
+            "attn_post_norm": "post_attention_layernorm",
+            "ln2": "pre_feedforward_layernorm",
+            "ffn_post_norm": "post_feedforward_layernorm",
+        }
+        for gguf_suffix, hf_suffix in suffix_map.items():
+            if suffix == gguf_suffix or suffix.startswith(f"{gguf_suffix}."):
+                return layer + "." + hf_suffix + suffix.removeprefix(gguf_suffix)
+        return None
+
+    @classmethod
+    def map_name(cls, name: str) -> str | None:
+        return cls._map_vision_name(name) or cls._map_text_name(name)
+
+    @staticmethod
+    def _weight_files(model_path: str) -> list[str]:
+        files = [model_path]
+        if mm_proj_path := detect_gguf_multimodal(model_path):
+            files.append(str(mm_proj_path))
+        return files
+
+    def prepare_loading(
+        self,
+        model_path: str,
+        model_config: ModelConfig,
+    ) -> GGUFLoadSpec:
+        model_config.hf_config = self.patch_hf_config(
+            model_path, model_config.hf_config
+        )
+        weight_files = self._weight_files(model_path)
+        unquantized_modules = {
+            mapped.rsplit(".", 1)[0] if mapped.endswith(".weight") else mapped
+            for name in get_gguf_unquantized_params(weight_files)
+            if (mapped := self.map_name(name)) is not None
+        }
+        self.load_spec = GGUFLoadSpec(
+            weights_source=weight_files,
+            unquantized_modules=list(unquantized_modules),
+        )
+        return self.load_spec
+
+    @staticmethod
+    def _split_expert_weights(
+        name: str, weight: torch.Tensor
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        if ".experts.0.gate_up_proj." in name:
+            gate_name = name.replace("gate_up_proj", "gate_proj")
+            up_name = name.replace("gate_up_proj", "up_proj")
+            if weight.ndim == 0:
+                yield gate_name, weight
+                yield up_name, weight
+                return
+            for expert_id, expert_weight in enumerate(weight.unbind()):
+                gate_weight, up_weight = expert_weight.chunk(2, dim=0)
+                expert = f".experts.{expert_id}."
+                yield gate_name.replace(".experts.0.", expert), gate_weight
+                yield up_name.replace(".experts.0.", expert), up_weight
+            return
+
+        if weight.ndim == 3 and ".experts.0." in name:
+            for expert_id, expert_weight in enumerate(weight.unbind()):
+                yield (
+                    name.replace(".experts.0.", f".experts.{expert_id}."),
+                    expert_weight,
+                )
+            return
+        yield name, weight
+
+    def prepare_weights(
+        self,
+        model_config: ModelConfig,
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        del model_config
+        weights = gguf_quant_weights_iterator_multi(self.load_spec.weights_source)
+        for raw_name, weight in weights:
+            name = self.map_name(raw_name)
+            if name is None:
+                continue
+            if name == "model.vision_tower.patch_embedder.input_proj.weight":
+                weight = weight.flatten(1)
+            yield from self._split_expert_weights(name, weight)

--- a/vllm_gguf_plugin/weights_adapter/gemma4.py
+++ b/vllm_gguf_plugin/weights_adapter/gemma4.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import torch
 from vllm.logger import init_logger
+from vllm.model_executor.models.utils import WeightsMapper
 
 from ..gguf_files import GGUFModelFiles
 from ..gguf_utils import maybe_patch_hf_config_from_gguf
@@ -20,6 +20,81 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
 logger = init_logger(__name__)
+
+GEMMA4_TEXT_SUBSTR: dict[str, str] = {
+    "attn_q_norm.": "self_attn.q_norm.",
+    "attn_k_norm.": "self_attn.k_norm.",
+    "attn_q.": "self_attn.q_proj.",
+    "attn_k.": "self_attn.k_proj.",
+    "attn_v.": "self_attn.v_proj.",
+    "attn_output.": "self_attn.o_proj.",
+    "attn_norm.": "input_layernorm.",
+    "post_attention_norm.": "post_attention_layernorm.",
+    "ffn_norm.": "pre_feedforward_layernorm.",
+    "post_ffw_norm_1.": "post_feedforward_layernorm_1.",
+    "post_ffw_norm_2.": "post_feedforward_layernorm_2.",
+    "post_ffw_norm.": "post_feedforward_layernorm.",
+    "pre_ffw_norm_2.": "pre_feedforward_layernorm_2.",
+    "ffn_gate_inp.scale": "router.scale",
+    "ffn_gate_inp.": "router.proj.",
+    "ffn_down_exps.scale": "router.per_expert_scale",
+    "ffn_gate_up_exps.": "experts.0.gate_up_proj.",
+    "ffn_down_exps.": "experts.0.down_proj.",
+    "ffn_gate.": "mlp.gate_proj.",
+    "ffn_up.": "mlp.up_proj.",
+    "ffn_down.": "mlp.down_proj.",
+    "layer_output_scale.weight": "layer_scalar",
+    "layer_output_scale.": "layer_scalar.",
+}
+
+GEMMA4_VISION_SUBSTR: dict[str, str] = {
+    "attn_q_norm.": "self_attn.q_norm.",
+    "attn_k_norm.": "self_attn.k_norm.",
+    "attn_q.": "self_attn.q_proj.linear.",
+    "attn_k.": "self_attn.k_proj.linear.",
+    "attn_v.": "self_attn.v_proj.linear.",
+    "attn_out.": "self_attn.o_proj.linear.",
+    "ffn_gate.": "mlp.gate_proj.linear.",
+    "ffn_up.": "mlp.up_proj.linear.",
+    "ffn_down.": "mlp.down_proj.linear.",
+    "ln1.": "input_layernorm.",
+    "attn_post_norm.": "post_attention_layernorm.",
+    "ln2.": "pre_feedforward_layernorm.",
+    "ffn_post_norm.": "post_feedforward_layernorm.",
+}
+
+
+def build_gemma4_text_mapper() -> WeightsMapper:
+    return WeightsMapper(
+        orig_to_new_prefix={
+            "token_embd.": "model.language_model.embed_tokens.",
+            "blk.": "model.language_model.layers.",
+            "output_norm.": "model.language_model.norm.",
+            "output.": "lm_head.",
+        },
+        orig_to_new_substr=GEMMA4_TEXT_SUBSTR,
+    )
+
+
+def build_gemma4_vision_mapper() -> WeightsMapper:
+    return WeightsMapper(
+        orig_to_new_prefix={
+            "v.position_embd.weight": (
+                "model.vision_tower.patch_embedder.position_embedding_table"
+            ),
+            "v.std_bias": "model.vision_tower.std_bias",
+            "v.std_scale": "model.vision_tower.std_scale",
+            "v.patch_embd.": "model.vision_tower.patch_embedder.input_proj.",
+            "v.blk.": "model.vision_tower.encoder.layers.",
+            "mm.input_projection": "model.embed_vision.embedding_projection",
+        },
+        orig_to_new_substr=GEMMA4_VISION_SUBSTR,
+    )
+
+
+def _map_tensor_name(mapper: WeightsMapper, name: str) -> str | None:
+    mapped = mapper.apply_list([name])[0]
+    return mapped if mapped != name else None
 
 
 class Gemma4GGUFAdapter(BaseGGUFWeightsAdapter):
@@ -41,95 +116,13 @@ class Gemma4GGUFAdapter(BaseGGUFWeightsAdapter):
         )
 
     @staticmethod
-    def _map_text_name(name: str) -> str | None:
-        top_level = {
-            "token_embd": "model.language_model.embed_tokens",
-            "output_norm": "model.language_model.norm",
-            "output": "lm_head",
-        }
-        for gguf_prefix, hf_prefix in top_level.items():
-            if name == gguf_prefix or name.startswith(f"{gguf_prefix}."):
-                return hf_prefix + name.removeprefix(gguf_prefix)
-
-        match = re.fullmatch(r"blk\.(\d+)\.(.+)", name)
-        if match is None:
-            return None
-        layer_idx, suffix = match.groups()
-        layer = f"model.language_model.layers.{layer_idx}"
-        suffix_map = {
-            "attn_q": "self_attn.q_proj",
-            "attn_k": "self_attn.k_proj",
-            "attn_v": "self_attn.v_proj",
-            "attn_output": "self_attn.o_proj",
-            "attn_q_norm": "self_attn.q_norm",
-            "attn_k_norm": "self_attn.k_norm",
-            "attn_norm": "input_layernorm",
-            "post_attention_norm": "post_attention_layernorm",
-            "ffn_norm": "pre_feedforward_layernorm",
-            "post_ffw_norm": "post_feedforward_layernorm",
-            "post_ffw_norm_1": "post_feedforward_layernorm_1",
-            "post_ffw_norm_2": "post_feedforward_layernorm_2",
-            "pre_ffw_norm_2": "pre_feedforward_layernorm_2",
-            "ffn_gate": "mlp.gate_proj",
-            "ffn_up": "mlp.up_proj",
-            "ffn_down": "mlp.down_proj",
-            "ffn_gate_inp": "router.proj",
-            "ffn_gate_inp.scale": "router.scale",
-            "ffn_down_exps.scale": "router.per_expert_scale",
-            "layer_output_scale": "layer_scalar",
-            "layer_output_scale.weight": "layer_scalar",
-            "ffn_gate_up_exps": "experts.0.gate_up_proj",
-            "ffn_down_exps": "experts.0.down_proj",
-        }
-        for gguf_suffix, hf_suffix in sorted(
-            suffix_map.items(), key=lambda item: len(item[0]), reverse=True
-        ):
-            if suffix == gguf_suffix or suffix.startswith(f"{gguf_suffix}."):
-                return layer + "." + hf_suffix + suffix.removeprefix(gguf_suffix)
-        return None
-
-    @staticmethod
-    def _map_vision_name(name: str) -> str | None:
-        if name == "v.position_embd.weight":
-            return "model.vision_tower.patch_embedder.position_embedding_table"
-        direct = {
-            "v.std_bias": "model.vision_tower.std_bias",
-            "v.std_scale": "model.vision_tower.std_scale",
-            "v.patch_embd": "model.vision_tower.patch_embedder.input_proj",
-            "mm.input_projection": "model.embed_vision.embedding_projection",
-        }
-        for gguf_prefix, hf_prefix in direct.items():
-            if name == gguf_prefix or name.startswith(f"{gguf_prefix}."):
-                return hf_prefix + name.removeprefix(gguf_prefix)
-
-        match = re.fullmatch(r"v\.blk\.(\d+)\.(.+)", name)
-        if match is None:
-            return None
-        layer_idx, suffix = match.groups()
-        layer = f"model.vision_tower.encoder.layers.{layer_idx}"
-        suffix_map = {
-            "attn_q": "self_attn.q_proj.linear",
-            "attn_k": "self_attn.k_proj.linear",
-            "attn_v": "self_attn.v_proj.linear",
-            "attn_out": "self_attn.o_proj.linear",
-            "attn_q_norm": "self_attn.q_norm",
-            "attn_k_norm": "self_attn.k_norm",
-            "ffn_gate": "mlp.gate_proj.linear",
-            "ffn_up": "mlp.up_proj.linear",
-            "ffn_down": "mlp.down_proj.linear",
-            "ln1": "input_layernorm",
-            "attn_post_norm": "post_attention_layernorm",
-            "ln2": "pre_feedforward_layernorm",
-            "ffn_post_norm": "post_feedforward_layernorm",
-        }
-        for gguf_suffix, hf_suffix in suffix_map.items():
-            if suffix == gguf_suffix or suffix.startswith(f"{gguf_suffix}."):
-                return layer + "." + hf_suffix + suffix.removeprefix(gguf_suffix)
-        return None
-
-    @classmethod
-    def map_name(cls, name: str) -> str | None:
-        return cls._map_vision_name(name) or cls._map_text_name(name)
+    def map_name(name: str) -> str | None:
+        mapper = (
+            build_gemma4_vision_mapper()
+            if name.startswith(("v.", "mm."))
+            else build_gemma4_text_mapper()
+        )
+        return _map_tensor_name(mapper, name)
 
     def build_name_map(
         self,
@@ -137,10 +130,13 @@ class Gemma4GGUFAdapter(BaseGGUFWeightsAdapter):
         model_config: ModelConfig,
     ) -> dict[str, str]:
         del model_config
+        text_mapper = build_gemma4_text_mapper()
+        vision_mapper = build_gemma4_vision_mapper()
         name_map: dict[str, str] = {}
         unmapped: list[str] = []
         for name in sorted(get_gguf_tensor_names(files.all_files)):
-            if mapped := self.map_name(name):
+            mapper = vision_mapper if name.startswith(("v.", "mm.")) else text_mapper
+            if mapped := _map_tensor_name(mapper, name):
                 name_map[name] = mapped
             else:
                 unmapped.append(name)


### PR DESCRIPTION
# Add Gemma 4 GGUF support

## Summary

This PR adds GGUF weight loading support for Gemma 4 text and multimodal models.

- Register a Gemma 4 weights adapter.
- Map text, vision, multimodal projection, router, and expert tensor names from GGUF to the vLLM model layout.
- Split packed MoE gate/up and per-expert tensors into the weights expected by vLLM.
- Reshape the vision patch-embedding weight during loading.
- Add adapter-level coverage and a slow multimodal GGUF integration test using `google/gemma-4-26B-A4B-it` and `unsloth/gemma-4-26B-A4B-it-GGUF:Q4_K_M`.

## Testing

- `pytest -q tests/test_gemma4_adapter.py`
  - 2 passed
- `pytest -vv -s tests/test_multimodal_gguf.py::test_gemma4_mm_gguf`
  - 1 passed in 295.05 seconds on an AMD Radeon 8060S

The integration test validates GGUF loading, multimodal preprocessing and vision encoding, model prefill, and first-token generation against the Hugging Face model.

### online benchmark 

```bash
vllm serve "unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M" \
  --tokenizer "google/gemma-4-26B-A4B-it" \
  --served-model-name "google/gemma-4-26B-A4B-it"
```
<img width="1309" height="508" alt="image" src="https://github.com/user-attachments/assets/88c7df0c-ddba-4e5b-ab2c-e9cad8a0fd09" />

this is benched with guidellm across concurrency 1-8 on the same prefix extending workload.

## Known limitation

Multi-token comparison is currently limited by a Transformers/ROCm issue: the Hugging Face Gemma 4 model produces finite logits for the first generated token, but every logit becomes NaN on the first cached decode step.

This was reproduced with Transformers 5.15.0, PyTorch 2.11.0, and ROCm 7.14. The Gemma 4 integration test therefore compares one generated token. Adapter-level tests separately cover the tensor-name mapping and packed-expert transformation.
