### PR TITLE
[BugFix] Fix quant file selection in download_gguf

### DIFF
--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -111,6 +111,7 @@ class TestGGUFDownload:
     def test_download_gguf_finds_quant_published_in_a_subdirectory(
         self, mock_download, tmp_path
     ):
+        """snapshot_download's fnmatch spans '/', so the local scan must too."""
         folder = self._make_repo(
             tmp_path,
             [
@@ -133,6 +134,30 @@ class TestGGUFDownload:
         result = download_gguf("unsloth/Some-GGUF", "Q6_K")
 
         assert result == f"{folder}/model-Q6_K.gguf"
+
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_skips_the_multimodal_projector(
+        self, mock_download, tmp_path
+    ):
+        """A bare precision quant type also matches ``mmproj-BF16.gguf``."""
+        folder = self._make_repo(
+            tmp_path, ["mmproj-BF16.gguf", "gemma-3-4b-it-BF16.gguf"]
+        )
+        mock_download.return_value = folder
+
+        result = download_gguf("unsloth/gemma-3-4b-it-GGUF", "BF16")
+
+        assert result == f"{folder}/gemma-3-4b-it-BF16.gguf"
+
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_raises_when_only_a_projector_matches(
+        self, mock_download, tmp_path
+    ):
+        folder = self._make_repo(tmp_path, ["mmproj-F16.gguf"])
+        mock_download.return_value = folder
+
+        with pytest.raises(ValueError, match="Downloaded GGUF files not found"):
+            download_gguf("unsloth/gemma-3-4b-it-GGUF", "F16")
 
     @patch("vllm_gguf_plugin.weight_utils.hf_hub_download")
     @patch("vllm_gguf_plugin.weight_utils.list_filtered_repo_files")

--- a/tests/test_gguf_download.py
+++ b/tests/test_gguf_download.py
@@ -96,6 +96,44 @@ class TestGGUFDownload:
         with pytest.raises(ValueError, match="Downloaded GGUF files not found"):
             download_gguf("unsloth/Qwen3-0.6B-GGUF", "IQ1_S")
 
+    # The tests above mock glob.glob, so they assert the mock rather than the
+    # resolution. These use a real directory tree instead.
+
+    @staticmethod
+    def _make_repo(root, names):
+        for name in names:
+            path = root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+        return str(root)
+
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_finds_quant_published_in_a_subdirectory(
+        self, mock_download, tmp_path
+    ):
+        folder = self._make_repo(
+            tmp_path,
+            [
+                "UD-Q2_K_XL/model-UD-Q2_K_XL-00001-of-00002.gguf",
+                "UD-Q2_K_XL/model-UD-Q2_K_XL-00002-of-00002.gguf",
+                "UD-Q4_K_XL/model-UD-Q4_K_XL-00001-of-00001.gguf",
+            ],
+        )
+        mock_download.return_value = folder
+
+        result = download_gguf("unsloth/Some-MoE-GGUF", "UD-Q2_K_XL")
+
+        assert result == f"{folder}/UD-Q2_K_XL/model-UD-Q2_K_XL-00001-of-00002.gguf"
+
+    @patch("vllm_gguf_plugin.weight_utils.snapshot_download")
+    def test_download_gguf_still_finds_top_level_files(self, mock_download, tmp_path):
+        folder = self._make_repo(tmp_path, ["model-Q6_K.gguf", "model-Q8_0.gguf"])
+        mock_download.return_value = folder
+
+        result = download_gguf("unsloth/Some-GGUF", "Q6_K")
+
+        assert result == f"{folder}/model-Q6_K.gguf"
+
     @patch("vllm_gguf_plugin.weight_utils.hf_hub_download")
     @patch("vllm_gguf_plugin.weight_utils.list_filtered_repo_files")
     def test_download_mmproj_prefers_bfloat16(self, mock_list, mock_download):

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -40,16 +40,22 @@ def download_gguf(
         ignore_patterns=ignore_patterns,
     )
 
-    local_files: list[str] = []
+    matched: set[str] = set()
     for pattern in allow_patterns:
-        local_files.extend(glob.glob(os.path.join(folder, pattern)))
+        # snapshot_download matched these patterns with fnmatch against
+        # repo-relative paths, where * spans "/". glob does not cross a
+        # directory separator, so "**" is needed to see the same files.
+        matched.update(glob.glob(os.path.join(folder, "**", pattern), recursive=True))
+
+    local_files = list(matched)
 
     if not local_files:
         raise ValueError(
             f"Downloaded GGUF files not found in {folder} for quant_type {quant_type}"
         )
 
-    local_files.sort(key=lambda x: (x.count("-"), x))
+    # Rank on the file name; a subdirectory would skew the shard heuristic.
+    local_files.sort(key=lambda path: (os.path.basename(path).count("-"), path))
     return local_files[0]
 
 

--- a/vllm_gguf_plugin/weight_utils.py
+++ b/vllm_gguf_plugin/weight_utils.py
@@ -42,19 +42,28 @@ def download_gguf(
 
     matched: set[str] = set()
     for pattern in allow_patterns:
-        # snapshot_download matched these patterns with fnmatch against
-        # repo-relative paths, where * spans "/". glob does not cross a
-        # directory separator, so "**" is needed to see the same files.
+        # ``snapshot_download`` matched these same patterns with fnmatch against
+        # repo-relative paths, where ``*`` spans ``/``. Plain ``glob`` does not
+        # cross a directory separator, so a quant published in a per-quant
+        # subdirectory was downloaded and then reported as missing. ``**`` with
+        # recursive=True matches zero or more directories, which covers both
+        # layouts.
         matched.update(glob.glob(os.path.join(folder, "**", pattern), recursive=True))
 
-    local_files = list(matched)
+    # A bare precision quant type such as BF16 also matches ``mmproj-BF16.gguf``.
+    # The projector is resolved separately by ``download_mmproj``; returning it
+    # here would load the vision tower as the backbone.
+    local_files = [
+        path for path in matched if "mmproj" not in os.path.basename(path).lower()
+    ]
 
     if not local_files:
         raise ValueError(
             f"Downloaded GGUF files not found in {folder} for quant_type {quant_type}"
         )
 
-    # Rank on the file name; a subdirectory would skew the shard heuristic.
+    # Rank on the file name alone: a subdirectory component would otherwise
+    # count towards the shard heuristic and reorder the candidates.
     local_files.sort(key=lambda path: (os.path.basename(path).count("-"), path))
     return local_files[0]
 


### PR DESCRIPTION
`download_gguf` hands its patterns to `snapshot_download`, which matches them with `fnmatch` against repo-relative paths where `*` spans `/`, then re-matches the same patterns locally with `glob`, where `*` does not. A repo that publishes each quant in its own folder therefore downloads fine and then dies with `Downloaded GGUF files not found`. That is most of the big MoE repos: all 363 gguf files in `unsloth/Kimi-K2-Instruct-GGUF` sit in subdirectories, and `unsloth/DeepSeek-V3.1-GGUF`, `Qwen/Qwen3-235B-A22B-GGUF`, and `unsloth/gpt-oss-120b-GGUF` are the same. Using `**` with `recursive=True` makes the local scan see what was downloaded.

The same patterns also match the projector. For `:BF16`, the candidates are `mmproj-BF16.gguf` and `gemma-3-4b-it-BF16.gguf`, and the `(count("-"), name)` tie-break prefers the mmproj, so the vision tower comes back as the backbone. `download_mmproj` already resolves the projector, so I exclude it here and rank on the file name instead of the full path.

One behaviour change worth flagging: `unsloth/gemma-3-4b-it-GGUF:F16` publishes no F16 backbone, only BF16. It used to resolve to the projector and load it as the model; now it raises the existing "not found" error.

`test_download_gguf_subdir` mocked `glob.glob` into returning a subdirectory hit for any matching pattern, so it passed against code that could not do it. I left it and added four tests that build a real directory tree.