### PR TITLE
fix(moe_vec): chunk launches when tokens*top_k exceeds gridDim.z limit

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -361,6 +361,61 @@ def test_moe(
     torch.testing.assert_close(output, ref_output, atol=1, rtol=1e-1)
 
 
+@pytest.mark.parametrize("num_tokens", [9000])
+@pytest.mark.parametrize("hidden_size", [512])
+@pytest.mark.parametrize("top_k", [8])
+@pytest.mark.parametrize("dtype", [torch.half])
+@pytest.mark.parametrize(
+    "quant_type", [GGMLQuantizationType.IQ1_M, GGMLQuantizationType.Q4_0]
+)
+@torch.inference_mode()
+def test_moe_large_batch(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    quant_type: GGMLQuantizationType,
+    top_k: int,
+):
+    # num_tokens * top_k exceeds the 65535 gridDim.z limit of the MMVQ MoE
+    # kernel, exercising the chunked launch path.
+    seed_everything(0)
+    H, E = 1024, 256
+
+    x = torch.rand((num_tokens, H), dtype=dtype, device="cuda")
+
+    topk_weights = torch.rand(num_tokens, top_k, device="cuda", dtype=dtype)
+    topk_ids = torch.randint(
+        0, E, (num_tokens, top_k), device="cuda", dtype=torch.int32
+    )
+
+    tensors = get_gguf_moe_tensors(hidden_size, quant_type)
+
+    w13 = tensors[0]
+    w2 = tensors[1]
+
+    w13_dequant = torch.tensor(dequantize(w13.data, quant_type), device="cuda").to(
+        dtype
+    )
+
+    w2_dequant = torch.tensor(dequantize(w2.data, quant_type), device="cuda").to(dtype)
+
+    output = _fused_moe_gguf(
+        x,
+        torch.tensor(w13.data, device="cuda"),
+        torch.tensor(w2.data, device="cuda"),
+        topk_weights,
+        topk_ids,
+        quant_type,
+        quant_type,
+        "silu",
+    )
+
+    ref_output = fused_experts(
+        x, w13_dequant, w2_dequant, topk_weights, topk_ids
+    ).reshape(output.shape)
+    torch.testing.assert_close(output, ref_output, atol=1, rtol=1e-1)
+
+
 @pytest.mark.parametrize("num_tokens", [83, 128])
 @pytest.mark.parametrize("hidden_size", [512])
 @pytest.mark.parametrize("top_k", [4, 8])

--- a/vllm_gguf_plugin/csrc/gguf/moe_vec.cuh
+++ b/vllm_gguf_plugin/csrc/gguf/moe_vec.cuh
@@ -52,287 +52,80 @@ static __global__ void moe_vec_q(const void* __restrict__ vx,
   }
 }
 
-template <typename scalar_t>
-static void moe_vec_q4_0_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
+// The launch grid puts tokens * top_k in the z dimension, which is limited to
+// 65535 blocks, so large token counts are split into per-token-range chunks.
+template <typename scalar_t, int qk, int qi, typename block_q_t, int vdr,
+          vec_dot_q_cuda_t vec_dot_q_cuda>
+static void launch_moe_vec_q(const void* vx, const void* vy, scalar_t* dst,
+                             const int* topk_ids, const int top_k,
+                             const int tokens, const int ncols, const int nrows,
+                             const int token_stride, cudaStream_t stream) {
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK4_0, QI4_0, block_q4_0, VDR_Q4_0_Q8_1_MMVQ,
-            vec_dot_q4_0_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
+  const int max_tokens_per_launch = 65535 / top_k;
+  for (int tok_off = 0; tok_off < tokens; tok_off += max_tokens_per_launch) {
+    const int chunk_tokens = tokens - tok_off < max_tokens_per_launch
+                                 ? tokens - tok_off
+                                 : max_tokens_per_launch;
+    const dim3 block_nums(block_num_y, 1, chunk_tokens * top_k);
+    const int64_t off = static_cast<int64_t>(tok_off) * top_k;
+    moe_vec_q<scalar_t, qk, qi, block_q_t, vdr, vec_dot_q_cuda>
+        <<<block_nums, block_dims, 0, stream>>>(
+            vx, ((const int*)vy) + tok_off * token_stride, dst + off * nrows,
+            topk_ids + off, top_k, ncols, nrows, token_stride);
+  }
 }
 
-template <typename scalar_t>
-static void moe_vec_q4_1_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK4_0, QI4_1, block_q4_1, VDR_Q4_1_Q8_1_MMVQ,
-            vec_dot_q4_1_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
+#define MOE_VEC_Q8_1_LAUNCHER(launcher_name, qk, qi, block_q_t, vdr,        \
+                              vec_dot)                                      \
+  template <typename scalar_t>                                              \
+  static void launcher_name(const void* vx, const void* vy, scalar_t* dst,  \
+                            const int* topk_ids, const int top_k,           \
+                            const int tokens, const int ncols,              \
+                            const int nrows, const int token_stride,        \
+                            cudaStream_t stream) {                          \
+    launch_moe_vec_q<scalar_t, qk, qi, block_q_t, vdr, vec_dot>(            \
+        vx, vy, dst, topk_ids, top_k, tokens, ncols, nrows, token_stride,   \
+        stream);                                                            \
+  }
 
-template <typename scalar_t>
-static void moe_vec_q5_0_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK5_0, QI5_0, block_q5_0, VDR_Q5_0_Q8_1_MMVQ,
-            vec_dot_q5_0_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q4_0_q8_1_cuda, QK4_0, QI4_0, block_q4_0,
+                      VDR_Q4_0_Q8_1_MMVQ, vec_dot_q4_0_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q4_1_q8_1_cuda, QK4_0, QI4_1, block_q4_1,
+                      VDR_Q4_1_Q8_1_MMVQ, vec_dot_q4_1_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q5_0_q8_1_cuda, QK5_0, QI5_0, block_q5_0,
+                      VDR_Q5_0_Q8_1_MMVQ, vec_dot_q5_0_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q5_1_q8_1_cuda, QK5_0, QI5_1, block_q5_1,
+                      VDR_Q5_1_Q8_1_MMVQ, vec_dot_q5_1_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q8_0_q8_1_cuda, QK8_0, QI8_0, block_q8_0,
+                      VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q2_K_q8_1_cuda, QK_K, QI2_K, block_q2_K,
+                      VDR_Q2_K_Q8_1_MMVQ, vec_dot_q2_K_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q3_K_q8_1_cuda, QK_K, QI3_K, block_q3_K,
+                      VDR_Q3_K_Q8_1_MMVQ, vec_dot_q3_K_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q4_K_q8_1_cuda, QK_K, QI4_K, block_q4_K,
+                      VDR_Q4_K_Q8_1_MMVQ, vec_dot_q4_K_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q5_K_q8_1_cuda, QK_K, QI5_K, block_q5_K,
+                      VDR_Q5_K_Q8_1_MMVQ, vec_dot_q5_K_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_q6_K_q8_1_cuda, QK_K, QI6_K, block_q6_K,
+                      VDR_Q6_K_Q8_1_MMVQ, vec_dot_q6_K_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq2_xxs_q8_1_cuda, QK_K, QI2_XXS, block_iq2_xxs,
+                      1, vec_dot_iq2_xxs_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq2_xs_q8_1_cuda, QK_K, QI2_XS, block_iq2_xs, 1,
+                      vec_dot_iq2_xs_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq2_s_q8_1_cuda, QK_K, QI2_S, block_iq2_s, 1,
+                      vec_dot_iq2_s_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq3_xxs_q8_1_cuda, QK_K, QI3_XXS, block_iq3_xxs,
+                      1, vec_dot_iq3_xxs_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq1_s_q8_1_cuda, QK_K, QI1_S, block_iq1_s, 1,
+                      vec_dot_iq1_s_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq1_m_q8_1_cuda, QK_K, QI1_M, block_iq1_m, 1,
+                      vec_dot_iq1_m_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq4_nl_q8_1_cuda, QK4_NL, QI4_NL, block_iq4_nl,
+                      VDR_Q4_0_Q8_1_MMVQ, vec_dot_iq4_nl_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq4_xs_q8_1_cuda, QK_K, QI4_XS, block_iq4_xs, 1,
+                      vec_dot_iq4_xs_q8_1)
+MOE_VEC_Q8_1_LAUNCHER(moe_vec_iq3_s_q8_1_cuda, QK_K, QI3_XS, block_iq3_s, 1,
+                      vec_dot_iq3_s_q8_1)
 
-template <typename scalar_t>
-static void moe_vec_q5_1_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK5_1, QI5_1, block_q5_1, VDR_Q5_1_Q8_1_MMVQ,
-            vec_dot_q5_1_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_q8_0_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK8_0, QI8_0, block_q8_0, VDR_Q8_0_Q8_1_MMVQ,
-            vec_dot_q8_0_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_q2_K_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI2_K, block_q2_K, VDR_Q2_K_Q8_1_MMVQ,
-            vec_dot_q2_K_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_q3_K_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI3_K, block_q3_K, VDR_Q3_K_Q8_1_MMVQ,
-            vec_dot_q3_K_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_q4_K_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI4_K, block_q4_K, VDR_Q4_K_Q8_1_MMVQ,
-            vec_dot_q4_K_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_q5_K_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI5_K, block_q5_K, VDR_Q5_K_Q8_1_MMVQ,
-            vec_dot_q5_K_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_q6_K_q8_1_cuda(const void* vx, const void* vy,
-                                   scalar_t* dst, const int* topk_ids,
-                                   const int top_k, const int tokens,
-                                   const int ncols, const int nrows,
-                                   const int token_stride,
-                                   cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI6_K, block_q6_K, VDR_Q6_K_Q8_1_MMVQ,
-            vec_dot_q6_K_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq2_xxs_q8_1_cuda(const void* vx, const void* vy,
-                                      scalar_t* dst, const int* topk_ids,
-                                      const int top_k, const int tokens,
-                                      const int ncols, const int nrows,
-                                      const int token_stride,
-                                      cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI2_XXS, block_iq2_xxs, 1, vec_dot_iq2_xxs_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq2_xs_q8_1_cuda(const void* vx, const void* vy,
-                                     scalar_t* dst, const int* topk_ids,
-                                     const int top_k, const int tokens,
-                                     const int ncols, const int nrows,
-                                     const int token_stride,
-                                     cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI2_XS, block_iq2_xs, 1, vec_dot_iq2_xs_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq2_s_q8_1_cuda(const void* vx, const void* vy,
-                                    scalar_t* dst, const int* topk_ids,
-                                    const int top_k, const int tokens,
-                                    const int ncols, const int nrows,
-                                    const int token_stride,
-                                    cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI2_S, block_iq2_s, 1, vec_dot_iq2_s_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq3_xxs_q8_1_cuda(const void* vx, const void* vy,
-                                      scalar_t* dst, const int* topk_ids,
-                                      const int top_k, const int tokens,
-                                      const int ncols, const int nrows,
-                                      const int token_stride,
-                                      cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI3_XXS, block_iq3_xxs, 1, vec_dot_iq3_xxs_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq1_s_q8_1_cuda(const void* vx, const void* vy,
-                                    scalar_t* dst, const int* topk_ids,
-                                    const int top_k, const int tokens,
-                                    const int ncols, const int nrows,
-                                    const int token_stride,
-                                    cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI1_S, block_iq1_s, 1, vec_dot_iq1_s_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq1_m_q8_1_cuda(const void* vx, const void* vy,
-                                    scalar_t* dst, const int* topk_ids,
-                                    const int top_k, const int tokens,
-                                    const int ncols, const int nrows,
-                                    const int token_stride,
-                                    cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI1_M, block_iq1_m, 1, vec_dot_iq1_m_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq4_nl_q8_1_cuda(const void* vx, const void* vy,
-                                     scalar_t* dst, const int* topk_ids,
-                                     const int top_k, const int tokens,
-                                     const int ncols, const int nrows,
-                                     const int token_stride,
-                                     cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK4_NL, QI4_NL, block_iq4_nl, VDR_Q4_0_Q8_1_MMVQ,
-            vec_dot_iq4_nl_q8_1><<<block_nums, block_dims, 0, stream>>>(
-      vx, vy, dst, topk_ids, top_k, ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq4_xs_q8_1_cuda(const void* vx, const void* vy,
-                                     scalar_t* dst, const int* topk_ids,
-                                     const int top_k, const int tokens,
-                                     const int ncols, const int nrows,
-                                     const int token_stride,
-                                     cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI4_XS, block_iq4_xs, 1, vec_dot_iq4_xs_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
-
-template <typename scalar_t>
-static void moe_vec_iq3_s_q8_1_cuda(const void* vx, const void* vy,
-                                    scalar_t* dst, const int* topk_ids,
-                                    const int top_k, const int tokens,
-                                    const int ncols, const int nrows,
-                                    const int token_stride,
-                                    cudaStream_t stream) {
-  const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
-  const dim3 block_nums(block_num_y, 1, tokens * top_k);
-  const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI3_XS, block_iq3_s, 1, vec_dot_iq3_s_q8_1>
-      <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
-                                              ncols, nrows, token_stride);
-}
+#undef MOE_VEC_Q8_1_LAUNCHER


### PR DESCRIPTION
## Problem

The MMVQ MoE kernels in `csrc/gguf/moe_vec.cuh` place `tokens * top_k` in the
z dimension of the launch grid:

```cpp
const dim3 block_nums(block_num_y, 1, tokens * top_k);
```

`gridDim.z` is hardware-capped at 65535. vLLM's default
`max_num_batched_tokens` is 8192, so any MMVQ-path MoE model with `top_k >= 8`
hits `8192 * 8 = 65536 > 65535` inside `profile_run` and the engine dies
during startup with:

```
RuntimeError: CUDA error: invalid argument
```

This was found while integrating the Hy3 (Hunyuan) architecture (#88), whose
IQ1_M experts (top_k 8) hit this limit in `profile_run` on every startup.

This is 100% reproducible on startup for such models with default settings —
it is not a load-dependent or intermittent failure. Decode-time batches are
small, so the limit is only reachable through the profile/dummy run or large
prefill batches.

The vec path is selected when both expert weight types are in
`MMVQ_QUANT_TYPES` but not on the MMQ gemm path
(`quantization/fused_moe.py`), which in practice means i-matrix (IQ*) quants —
the formats commonly used for large MoE GGUFs.

## Fix

Split the launch into per-token-range chunks so each launch keeps
`gridDim.z <= 65535`, mirroring the existing chunking pattern in
`quantize_row_q8_1_cuda` (`gguf_kernel.cu`):

```cpp
const int max_tokens_per_launch = 65535 / top_k;
for (int tok_off = 0; tok_off < tokens; tok_off += max_tokens_per_launch) {
  ...
}
```

Chunk boundaries align to whole tokens (multiples of `top_k` in grid z), and
the `vy` / `dst` / `topk_ids` pointers are offset accordingly, so kernel
indexing is unchanged. Single-launch cases take the same path as before with
one iteration.

The 19 per-type launcher bodies were byte-identical except for template
arguments, so they are consolidated into one `MOE_VEC_Q8_1_LAUNCHER` macro
(429 → 158 lines) while touching the launch logic.

## Test Plan / Test Result

New regression test `test_moe_large_batch` exercises the chunked launch path
directly: `num_tokens=9000, top_k=8` gives `9000 * 8 = 72000 > 65535`, which
crashed with `CUDA error: invalid argument` before the fix. It runs for both
`IQ1_M` (the motivating i-matrix case) and `Q4_0`, and compares against the
dequantized `fused_experts` reference.

Full run on an RTX PRO 6000 Blackwell (sm_120), torch 2.13.0+cu130, CUDA 13
toolchain, vLLM 0.27.0:

```
pytest tests/test_kernels.py::test_moe_large_batch -v
2 passed in 287.04s

pytest tests/test_kernels.py
1452 passed, 68 failed, 576 skipped in 3338.46s

pytest tests/test_plugin.py tests/test_gguf_utils.py
44 passed in 8.62s
```

The 68 failures are all `test_moe[*-dtype2-...]` cases failing inside the
triton reference kernel with `OutOfResources: shared memory, Required: 122880,
Hardware limit: 101376` — a hardware/triton limitation of this GPU unrelated
to the change. The identical failure set (same test IDs, same error) exists in
the baseline run on the parent commit recorded before this branch
(`69 failed` there = the same 68 kernel cases plus one unrelated
`test_plugin.py` ordering flake that passes in isolation and passes here).

`ruff check` on the full repo also passes.
